### PR TITLE
State machine implementation with hello world and led example

### DIFF
--- a/deviceshifu/pkg/deviceshifu/deviceshifu.go
+++ b/deviceshifu/pkg/deviceshifu/deviceshifu.go
@@ -14,6 +14,14 @@ import (
 	"k8s.io/client-go/rest"
 )
 
+var lastStateUpdateTime time.Time
+var stateMap = make(map[string]AvailableState)
+var currentState = "idle"
+var currentDefaultStateDuration int
+var currentDefaultTransition = "idle"
+var globalDefaultStateDuration int
+var globalDefaultTransition = "idle"
+
 type DeviceShifu struct {
 	Name              string
 	server            *http.Server
@@ -62,6 +70,7 @@ const (
 )
 
 func New(deviceShifuMetadata *DeviceShifuMetaData) (*DeviceShifu, error) {
+
 	if deviceShifuMetadata.Name == "" {
 		return nil, fmt.Errorf("DeviceShifu's name can't be empty\n")
 	}
@@ -74,7 +83,15 @@ func New(deviceShifuMetadata *DeviceShifuMetaData) (*DeviceShifu, error) {
 	if err != nil {
 		return nil, fmt.Errorf("Error parsing ConfigMap at %v\n", deviceShifuMetadata.ConfigFilePath)
 	}
+	log.Printf("New deviceShifuConfig:%v", deviceShifuConfig)
 
+	globalDefaultStateDuration = deviceShifuConfig.DeviceStates.GlobalDefaultStateDuration
+	globalDefaultTransition = deviceShifuConfig.DeviceStates.GlobalDefaultTransition
+	log.Printf("globalDefaultStateDuration:%v, globalDefaultTransition:%v\n", globalDefaultStateDuration, globalDefaultTransition)
+	for _, deviceState := range deviceShifuConfig.DeviceStates.AvailableStates {
+		stateMap[deviceState.State] = deviceState
+	}
+	log.Printf("Initialized stateMap:%v", stateMap)
 	mux := http.NewServeMux()
 	mux.HandleFunc("/health", deviceHealthHandler)
 	mux.HandleFunc("/", instructionNotFoundHandler)
@@ -193,10 +210,48 @@ func createUriFromRequest(address string, handlerInstruction string, r *http.Req
 
 func (handler DeviceCommandHandlerHTTP) commandHandleFunc() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+
 		handlerProperties := handler.deviceShifuHTTPHandlerMetaData.properties
 		handlerInstruction := handler.deviceShifuHTTPHandlerMetaData.instruction
 		handlerEdgeDeviceSpec := handler.deviceShifuHTTPHandlerMetaData.edgeDeviceSpec
 		handlerHTTPClient := handler.client.Client
+
+		availableInstructions := stateMap[currentState].AvailableInstructions
+		instructionAllowed := false
+		nextState := currentState
+		nextDefaultStateDuration := currentDefaultStateDuration
+		nextDefaultStateTransition := currentDefaultTransition
+		log.Printf("Received new instruction. Current statemap:%v, availableInstructions:%v\n", stateMap, availableInstructions)
+		for _, availableInstruction := range availableInstructions {
+			if availableInstruction.Instruction == handlerInstruction {
+				instructionAllowed = true
+				nextState = availableInstruction.NextState
+				nextDefaultStateDuration = stateMap[nextState].DefaultStateDuration
+				nextDefaultStateTransition = stateMap[nextState].DefaultTransition
+				if nextDefaultStateDuration == 0 {
+					nextDefaultStateDuration = globalDefaultStateDuration
+				}
+				if nextDefaultStateTransition == "" {
+					nextDefaultStateTransition = globalDefaultTransition
+				}
+				log.Printf("nextState:%v, nextDefaultStateDuration:%v, nextDefaultStateTransition:%v\n", nextState, nextDefaultStateDuration, nextDefaultStateTransition)
+				break
+			}
+		}
+		if !instructionAllowed {
+			log.Printf("Instruction %v is not allowed in state %v as its availableInstructions are %v\n", handlerInstruction, currentState, availableInstructions)
+			return
+		} else {
+			log.Printf("Transition from state %v to state %v\n", currentState, nextState)
+			log.Printf("Current state: currentState:%v, currentDefaultStateDuration:%v, currentDefaultTransition:%v, lastStateUpdateTime%v\n",
+				currentState, currentDefaultStateDuration, currentDefaultTransition, lastStateUpdateTime)
+			currentState = nextState
+			currentDefaultStateDuration = nextDefaultStateDuration
+			currentDefaultTransition = nextDefaultStateTransition
+			lastStateUpdateTime = time.Now()
+			log.Printf("New state: currentState:%v, currentDefaultStateDuration:%v, currentDefaultTransition:%v, lastStateUpdateTime%v\n",
+				currentState, currentDefaultStateDuration, currentDefaultTransition, lastStateUpdateTime)
+		}
 
 		if handlerProperties != nil {
 			// TODO: handle validation compile
@@ -477,11 +532,43 @@ func (ds *DeviceShifu) StartTelemetryCollection() error {
 	}
 }
 
+func (ds *DeviceShifu) StartStateMachine() error {
+	log.Println("Start state machine")
+	time.Sleep(time.Second)
+	for {
+		if lastStateUpdateTime.IsZero() {
+			continue
+		}
+		nowTime := time.Now()
+		timeDiff := nowTime.Sub(lastStateUpdateTime)
+		// log.Printf("State machine status: lastStateUpdateTime:%v, now:%v, diff:%v, threshold:%v\n", lastStateUpdateTime, nowTime, timeDiff.Seconds(), float64(currentDefaultStateDuration))
+		if timeDiff.Seconds() > float64(currentDefaultStateDuration) {
+			log.Printf("State timeout, transition from state %v to state %v; default duration %v, last update %v, currentDefaultStateDuration:%v, currentDefaultTransition:%v\n",
+				currentState, currentDefaultTransition, currentDefaultStateDuration, lastStateUpdateTime, currentDefaultStateDuration, currentDefaultTransition)
+			currentState = currentDefaultTransition
+			currentDefaultStateDuration = stateMap[currentState].DefaultStateDuration
+			currentDefaultTransition = stateMap[currentState].DefaultTransition
+			if currentDefaultStateDuration == 0 {
+				currentDefaultStateDuration = globalDefaultStateDuration
+			}
+			if currentDefaultTransition == "" {
+				currentDefaultTransition = globalDefaultTransition
+			}
+
+			lastStateUpdateTime = time.Now()
+
+			log.Printf("State timeout, transition from state %v to state %v; default duration %v, last update %v, currentDefaultStateDuration:%v, currentDefaultTransition:%v\n",
+				currentState, currentDefaultTransition, currentDefaultStateDuration, lastStateUpdateTime, currentDefaultStateDuration, currentDefaultTransition)
+		}
+		time.Sleep(time.Second)
+	}
+}
 func (ds *DeviceShifu) Start(stopCh <-chan struct{}) error {
 	fmt.Printf("deviceShifu %s started\n", ds.Name)
 
 	go ds.startHttpServer(stopCh)
 	go ds.StartTelemetryCollection()
+	go ds.StartStateMachine()
 
 	return nil
 }

--- a/deviceshifu/pkg/deviceshifu/deviceshifu_config.go
+++ b/deviceshifu/pkg/deviceshifu/deviceshifu_config.go
@@ -20,6 +20,7 @@ type DeviceShifuConfig struct {
 	driverProperties DeviceShifuDriverProperties
 	Instructions     map[string]*DeviceShifuInstruction
 	Telemetries      map[string]*DeviceShifuTelemetry
+	DeviceStates     States
 }
 
 type DeviceShifuDriverProperties struct {
@@ -48,6 +49,27 @@ type DeviceShifuTelemetry struct {
 	DeviceShifuTelemetryProperties DeviceShifuTelemetryProperties `yaml:"properties,omitempty"`
 }
 
+type AvailableInstruction struct {
+	Instruction     string `yaml:"availableInstruction"`
+	NextState       string `yaml:"nextState"`
+	AckReturn       string `yaml:"ackReturn,omitempty"`
+	DoneSignal      string `yaml:"doneSignal,omitempty"`
+	ExceptionReturn string `yaml:"exceptionReturn,omitempty"`
+}
+
+type AvailableState struct {
+	State                 string                 `yaml:"state"`
+	AvailableInstructions []AvailableInstruction `yaml:"availableInstructions,omitempty"`
+	DefaultStateDuration  int                    `yaml:"defaultStateDuration,omitempty"`
+	DefaultTransition     string                 `yaml:"defaultTransition,omitempty"`
+}
+
+type States struct {
+	GlobalDefaultStateDuration int              `yaml:"globalDefaultStateDuration"`
+	GlobalDefaultTransition    string           `yaml:"globalDefaultTransition"`
+	AvailableStates            []AvailableState `yaml:"availableStates"`
+}
+
 type EdgeDeviceConfig struct {
 	nameSpace      string
 	deviceName     string
@@ -58,6 +80,7 @@ const (
 	CM_DRIVERPROPERTIES_STR = "driverProperties"
 	CM_INSTRUCTIONS_STR     = "instructions"
 	CM_TELEMETRIES_STR      = "telemetries"
+	CM_STATES_STR           = "states"
 	EDGEDEVICE_RESOURCE_STR = "edgedevices"
 )
 
@@ -93,6 +116,14 @@ func NewDeviceShifuConfig(path string) (*DeviceShifuConfig, error) {
 		err = yaml.Unmarshal([]byte(telemetries), &dsc.Telemetries)
 		if err != nil {
 			log.Fatalf("Error parsing %v from ConfigMap, error: %v", CM_TELEMETRIES_STR, err)
+			return nil, err
+		}
+	}
+
+	if deviceStates, ok := cfg[CM_STATES_STR]; ok {
+		err = yaml.Unmarshal([]byte(deviceStates), &dsc.DeviceStates)
+		if err != nil {
+			log.Fatalf("Error parsing %v from ConfigMap, error: %v", CM_STATES_STR, err)
 			return nil, err
 		}
 	}

--- a/deviceshifu/pkg/deviceshifu/deviceshifu_config.go
+++ b/deviceshifu/pkg/deviceshifu/deviceshifu_config.go
@@ -58,16 +58,23 @@ type AvailableInstruction struct {
 }
 
 type AvailableState struct {
-	State                 string                 `yaml:"state"`
-	AvailableInstructions []AvailableInstruction `yaml:"availableInstructions,omitempty"`
-	DefaultStateDuration  int                    `yaml:"defaultStateDuration,omitempty"`
-	DefaultTransition     string                 `yaml:"defaultTransition,omitempty"`
+	State                        string                 `yaml:"state"`
+	AvailableInstructions        []AvailableInstruction `yaml:"availableInstructions,omitempty"`
+	DefaultStateDuration         int                    `yaml:"defaultStateDuration,omitempty"`
+	DefaultTransition            string                 `yaml:"defaultTransition,omitempty"`
+	DefaultTransitionInstruction string                 `yaml:"defaultTransitionInstruction,omitempty"`
 }
 
 type States struct {
-	GlobalDefaultStateDuration int              `yaml:"globalDefaultStateDuration"`
-	GlobalDefaultTransition    string           `yaml:"globalDefaultTransition"`
-	AvailableStates            []AvailableState `yaml:"availableStates"`
+	StateMachineEnabled                bool   `yaml:"stateMachineEnabled"`
+	InitialState                       string `yaml:"initialState"`
+	InitialInstruction                 string `yaml:"initialInstruction"`
+	GlobalDefaultTransitionInstruction string `yaml:"globalDefaultTransitionInstruction"`
+	// If you like push model, you can specify this endpoint for the deviceshifu to push state updates to your app
+	GlobalPushingApplicationEndpoint string           `yaml:"globalPushingApplicationEndpoint"`
+	GlobalDefaultStateDuration       int              `yaml:"globalDefaultStateDuration"`
+	GlobalDefaultTransition          string           `yaml:"globalDefaultTransition"`
+	AvailableStates                  []AvailableState `yaml:"availableStates"`
 }
 
 type EdgeDeviceConfig struct {

--- a/deviceshifu/pkg/deviceshifu/deviceshifu_config_test.go
+++ b/deviceshifu/pkg/deviceshifu/deviceshifu_config_test.go
@@ -23,6 +23,7 @@ type ConfigMapData struct {
 		DriverProperties string `yaml:"driverProperties"`
 		Instructions     string `yaml:"instructions"`
 		Telemetries      string `yaml:"telemetries"`
+		States           string `yaml:"states"`
 	} `yaml:"data"`
 }
 

--- a/docs/guide/hello-world-device/configuration/deviceshifu-helloworld-configmap.yaml
+++ b/docs/guide/hello-world-device/configuration/deviceshifu-helloworld-configmap.yaml
@@ -11,6 +11,7 @@ data:
 #    available instructions
   instructions: |
     hello:
+    idle:
 #    telemetry retrieval methods
 #    in this example, a device_health telemetry is collected by calling hello instruction every 1 second
   telemetries: |
@@ -20,8 +21,12 @@ data:
         initialDelayMs: 1000
         intervalMs: 1000
   states: |
-    globalDefaultStateDuration: 2
+    stateMachineEnabled: true
+    initialState: idle
+    initialInstruction: idle
+    globalDefaultStateDuration: 10
     globalDefaultTransition: idle
+    globalDefaultTransitionInstruction: idle
     availableStates:
     - state: idle
       availableInstructions:
@@ -30,14 +35,13 @@ data:
         ackReturn: HTTP 200
         doneSignal: HTTP 200
         exceptionReturn: HTTP 500
-      - availableInstruction: bye
+      - availableInstruction: idle
         nextState: idle
     - state: helloing
       defaultStateDuration: 5
-      defaultTransition: helloed
+      defaultTransition: idle
+      defaultTransitionInstruction: idle
       availableInstructions:
-      - availableInstruction: bye
+      - availableInstruction: idle
         nextState: idle
-    - state: helloed
-      defaultStateDuration: 10
 

--- a/docs/guide/hello-world-device/configuration/deviceshifu-helloworld-configmap.yaml
+++ b/docs/guide/hello-world-device/configuration/deviceshifu-helloworld-configmap.yaml
@@ -19,4 +19,25 @@ data:
         instruction: hello
         initialDelayMs: 1000
         intervalMs: 1000
+  states: |
+    globalDefaultStateDuration: 2
+    globalDefaultTransition: idle
+    availableStates:
+    - state: idle
+      availableInstructions:
+      - availableInstruction: hello
+        nextState: helloing
+        ackReturn: HTTP 200
+        doneSignal: HTTP 200
+        exceptionReturn: HTTP 500
+      - availableInstruction: bye
+        nextState: idle
+    - state: helloing
+      defaultStateDuration: 5
+      defaultTransition: helloed
+      availableInstructions:
+      - availableInstruction: bye
+        nextState: idle
+    - state: helloed
+      defaultStateDuration: 10
 

--- a/docs/guide/hello-world-device/helloworld.go
+++ b/docs/guide/hello-world-device/helloworld.go
@@ -9,6 +9,10 @@ func process_hello(w http.ResponseWriter, req *http.Request) {
 	fmt.Fprintln(w, "Hello_world from device via shifu!")
 }
 
+func process_idle(w http.ResponseWriter, req *http.Request) {
+	fmt.Fprintln(w, "I am idle!")
+}
+
 func headers(w http.ResponseWriter, req *http.Request) {
 	for name, headers := range req.Header {
 		for _, header := range headers {
@@ -19,6 +23,7 @@ func headers(w http.ResponseWriter, req *http.Request) {
 
 func main() {
 	http.HandleFunc("/hello", process_hello)
+	http.HandleFunc("/idle", process_idle)
 	http.HandleFunc("/headers", headers)
 
 	http.ListenAndServe(":11111", nil)

--- a/docs/guide/led/deviceshifu-led-configmap.yaml
+++ b/docs/guide/led/deviceshifu-led-configmap.yaml
@@ -1,0 +1,55 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: led-configmap-0.0.1
+  namespace: default
+data:
+  driverProperties: |
+    driverSku: rpi
+    driverImage: edgenesis/rpi:v0.0.1
+  instructions: |
+    led_control:
+    led_status:
+    led_red_on:
+    led_yellow_on:
+    led_green_on:
+# Telemetries are configurable health checks of the EdgeDevice
+# Developer/user can configure certain instructions to be used as health check
+# of the device. In this example, the device_health telemetry is mapped to
+# "get_status" instruction, executed every 1000 ms
+  telemetries: |
+    device_health:
+      properties:
+        instruction: led_status
+        initialDelayMs: 1000
+        intervalMs: 1000
+  states: |
+    initialState: red
+    initialInstruction: led_red_on
+    globalDefaultStateDuration: 10
+    globalDefaultTransition: red
+    globalDefaultTransitionInstruction: led_red_on
+    globalApplicationEndpoint: unityserver:8092
+    availableStates:
+    - state: red
+      defaultTransition: green
+      defaultTransitionInstruction: led_green_on
+      availableInstructions:
+      - availableInstruction: led_green_on
+        nextState: green
+    - state: green
+      defaultStateDuration: 6
+      defaultTransition: yellow
+      defaultTransitionInstruction: led_yellow_on
+      availableInstructions:
+      - availableInstruction: led_red_on
+        nextState: red
+      - availableInstruction: led_yellow_on
+        nextState: yellow
+    - state: yellow
+      defaultStateDuration: 3
+      availableInstructions:
+      - availableInstruction: led_red_on
+        nextState: red
+      - availableInstruction: led_green_on
+        nextState: green

--- a/docs/guide/led/deviceshifu-led-deployment.yaml
+++ b/docs/guide/led/deviceshifu-led-deployment.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: edgedevice-led-deployment
+  name: edgedevice-led-deployment
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: edgedevice-led-deployment
+  template:
+    metadata:
+      labels:
+        app: edgedevice-led-deployment
+    spec:
+      containers:
+      - image: edgehub/deviceshifu-http:v0.0.1
+        name: deviceshifu-http
+        ports:
+        - containerPort: 8080
+        volumeMounts:
+        - name: edgedevice-config
+          mountPath: "/etc/edgedevice/config"
+          readOnly: true
+        env:
+        - name: EDGEDEVICE_NAME
+          value: "edgedevice-led"
+        - name: EDGEDEVICE_NAMESPACE
+          value: "devices"
+      volumes:
+      - name: edgedevice-config
+        configMap:
+          name: led-configmap-0.0.1
+      serviceAccountName: edgedevice-mockdevice-sa

--- a/docs/guide/led/deviceshifu-led-service.yaml
+++ b/docs/guide/led/deviceshifu-led-service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: edgedevice-led-deployment
+  name: edgedevice-led
+  namespace: default
+spec:
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: edgedevice-led-deployment
+  type: LoadBalancer

--- a/docs/guide/led/led-edgedevice.yaml
+++ b/docs/guide/led/led-edgedevice.yaml
@@ -1,0 +1,10 @@
+apiVersion: shifu.edgenesis.io/v1alpha1
+kind: EdgeDevice
+metadata:
+  name: edgedevice-led
+  namespace: devices
+spec:
+  sku: "rpi" 
+  connection: Ethernet
+  address: 192.168.14.95:11122
+  protocol: HTTP

--- a/docs/guide/led/unityserver-service.yaml
+++ b/docs/guide/led/unityserver-service.yaml
@@ -1,0 +1,11 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: unityserver
+  namespace: default
+spec:
+  type: ExternalName
+  externalName: host.docker.internal
+  ports:
+    - name: port
+      port: 8092


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
This change introduces an automatic state machine which allows the user to specify all available states of a device shifu and make the work process fully automatic.

This is a low code development platform. With the state machine, we can enjoy the following benefits:
1. query the current state and info of the device at any time;
2. automate the device without writing any code;
3. let the device push state change to your application.

This change also modifies the helloworld example so it can run with state machine, and adds a new led example to show the automation.
**Will this PR make the community happier**? 
Yes.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
NA
**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```State machine implementation with hello world and led example
```
