### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,9 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+    ignore:
+      - dependency-name: "edgenesis.io/shifu/k8s/crd" # ignore update for shifu modules
+      - dependency-name: "edgenesis.io/shifu/deviceshifu/pkg/mockdevice/mockdevice" # ignore update for shifu modules
 
   - package-ecosystem: "gomod"
     directory: "k8s/crd" # Location of package manifests


### PR DESCRIPTION
ignore dependabot update for Shifu modules

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
This PR modifies `dependabot.yaml` to ignore `Shifu` related module update checks

**Will this PR make the community happier**? 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
- ignore dependabot update for Shifu modules
```
