### PR TITLE
[#Issue 93] Unify all HTTP-HTTP containers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,11 @@ IMAGE_VERSION = v0.0.1
 
 .PHONY: build-image-deviceshifu
 build-image-deviceshifu:
-	docker build -f ${PROJECT_ROOT}/deviceshifu/Dockerfile.deviceshifu --build-arg PROJECT_ROOT="${PROJECT_ROOT}" ${PROJECT_ROOT} -t edgehub/deviceshifu-http:${IMAGE_VERSION}
+	docker build -f ${PROJECT_ROOT}/deviceshifu/Dockerfile.deviceshifu --build-arg PROJECT_ROOT="${PROJECT_ROOT}" ${PROJECT_ROOT} -t edgehub/deviceshifu-http-http:${IMAGE_VERSION}
 
 .PHONY: buildx-push-image-deviceshifu
 buildx-push-image-deviceshifu:
-	docker buildx build --platform=linux/amd64,linux/arm64,linux/arm -f ${PROJECT_ROOT}/deviceshifu/Dockerfile.deviceshifu --build-arg PROJECT_ROOT="${PROJECT_ROOT}" ${PROJECT_ROOT} -t edgehub/deviceshifu-http-multi:${IMAGE_VERSION} --push
+	docker buildx build --platform=linux/amd64,linux/arm64,linux/arm -f ${PROJECT_ROOT}/deviceshifu/Dockerfile.deviceshifu --build-arg PROJECT_ROOT="${PROJECT_ROOT}" ${PROJECT_ROOT} -t edgehub/deviceshifu-http-http:${IMAGE_VERSION} --push
 	docker buildx build --platform=linux/amd64,linux/arm64,linux/arm -f ${PROJECT_ROOT}/deviceshifu/Dockerfile.deviceshifuMQTT --build-arg PROJECT_ROOT="${PROJECT_ROOT}" ${PROJECT_ROOT} -t edgehub/deviceshifu-http-mqtt:${IMAGE_VERSION} --push
 	docker buildx build --platform=linux/amd64,linux/arm64,linux/arm -f ${PROJECT_ROOT}/deviceshifu/Dockerfile.deviceshifuSocket --build-arg PROJECT_ROOT="${PROJECT_ROOT}" ${PROJECT_ROOT} -t edgehub/deviceshifu-http-socket:${IMAGE_VERSION} --push
 
@@ -23,7 +23,7 @@ download-demo-files:
 	docker pull edgehub/mockdevice-plate-reader:${IMAGE_VERSION}
 	docker pull edgehub/mockdevice-robot-arm:${IMAGE_VERSION}
 	docker pull edgehub/mockdevice-thermometer:${IMAGE_VERSION}
-	docker pull edgehub/deviceshifu-http:${IMAGE_VERSION}
+	docker pull edgehub/deviceshifu-http-http:${IMAGE_VERSION}
 	docker pull edgehub/edgedevice-controller:${IMAGE_VERSION}
 	docker pull quay.io/brancz/kube-rbac-proxy:v0.8.0
 	docker pull kindest/node:v1.21.1@sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6
@@ -36,7 +36,7 @@ compress-demo-files:
 	docker save edgehub/mockdevice-plate-reader:${IMAGE_VERSION} | gzip > build_dir/mockdevice-plate-reader.tar.gz
 	docker save edgehub/mockdevice-robot-arm:${IMAGE_VERSION} | gzip > build_dir/mockdevice-robot-arm.tar.gz
 	docker save edgehub/mockdevice-thermometer:${IMAGE_VERSION} | gzip > build_dir/mockdevice-thermometer.tar.gz
-	docker save edgehub/deviceshifu-http:${IMAGE_VERSION} | gzip > build_dir/deviceshifu-http.tar.gz
+	docker save edgehub/deviceshifu-http-http:${IMAGE_VERSION} | gzip > build_dir/deviceshifu-http-http.tar.gz
 	docker save edgehub/edgedevice-controller:${IMAGE_VERSION} | gzip > build_dir/edgedevice-controller.tar.gz
 	docker save kindest/node:v1.21.1@sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6 | gzip > build_dir/kind-image.tar.gz
 	docker save nginx:1.21 | gzip > build_dir/nginx.tar.gz
@@ -48,7 +48,7 @@ compress-edgenesis-files:
 	docker save edgehub/mockdevice-plate-reader:${IMAGE_VERSION} | gzip > build_dir/mockdevice-plate-reader.tar.gz
 	docker save edgehub/mockdevice-robot-arm:${IMAGE_VERSION} | gzip > build_dir/mockdevice-robot-arm.tar.gz
 	docker save edgehub/mockdevice-thermometer:${IMAGE_VERSION} | gzip > build_dir/mockdevice-thermometer.tar.gz
-	docker save edgehub/deviceshifu-http:${IMAGE_VERSION} | gzip > build_dir/deviceshifu-http.tar.gz
+	docker save edgehub/deviceshifu-http-http:${IMAGE_VERSION} | gzip > build_dir/deviceshifu-http-http.tar.gz
 	docker save edgehub/edgedevice-controller:${IMAGE_VERSION} | gzip > build_dir/edgedevice-controller.tar.gz
 
 .PHONY: build-deviceshifu-demo-image
@@ -71,7 +71,7 @@ buildx-push-image-mockdevices:
 
 
 docker-push-image-deviceshifu:
-	docker push edgehub/deviceshifu-http:${IMAGE_VERSION}
+	docker push edgehub/deviceshifu-http-http:${IMAGE_VERSION}
 
 docker-push-deviceshifu-demo-image:
 	docker push edgehub/demo-image-alpine:${IMAGE_VERSION}

--- a/deviceshifu/examples/demo_device/edgedevice-agv/deviceshifu-agv-deployment.yaml
+++ b/deviceshifu/examples/demo_device/edgedevice-agv/deviceshifu-agv-deployment.yaml
@@ -16,7 +16,7 @@ spec:
         app: edgedevice-agv-deployment
     spec:
       containers:
-      - image: edgehub/deviceshifu-http:v0.0.1
+      - image: edgehub/deviceshifu-http-http:v0.0.1
         name: deviceshifu-http
         ports:
         - containerPort: 8080

--- a/deviceshifu/examples/demo_device/edgedevice-plate-reader/deviceshifu-plate-reader-deployment.yaml
+++ b/deviceshifu/examples/demo_device/edgedevice-plate-reader/deviceshifu-plate-reader-deployment.yaml
@@ -16,7 +16,7 @@ spec:
         app: edgedevice-plate-reader-deployment
     spec:
       containers:
-      - image: edgehub/deviceshifu-http:v0.0.1
+      - image: edgehub/deviceshifu-http-http:v0.0.1
         name: deviceshifu-http
         ports:
         - containerPort: 8080

--- a/deviceshifu/examples/demo_device/edgedevice-robot-arm/deviceshifu-robot-arm-deployment.yaml
+++ b/deviceshifu/examples/demo_device/edgedevice-robot-arm/deviceshifu-robot-arm-deployment.yaml
@@ -16,7 +16,7 @@ spec:
         app: edgedevice-robotarm-deployment
     spec:
       containers:
-      - image: edgehub/deviceshifu-http:v0.0.1
+      - image: edgehub/deviceshifu-http-http:v0.0.1
         name: deviceshifu-http
         ports:
         - containerPort: 8080

--- a/deviceshifu/examples/demo_device/edgedevice-thermometer/deviceshifu-thermometer-deployment.yaml
+++ b/deviceshifu/examples/demo_device/edgedevice-thermometer/deviceshifu-thermometer-deployment.yaml
@@ -16,7 +16,7 @@ spec:
         app: edgedevice-thermometer-deployment
     spec:
       containers:
-      - image: edgehub/deviceshifu-http:v0.0.1
+      - image: edgehub/deviceshifu-http-http:v0.0.1
         name: deviceshifu-http
         ports:
         - containerPort: 8080

--- a/deviceshifu/examples/mockdevice/test-edgedevice-mockdevice-deployment.yaml
+++ b/deviceshifu/examples/mockdevice/test-edgedevice-mockdevice-deployment.yaml
@@ -15,7 +15,7 @@ spec:
         app: edgedevice-mockdevice-deployment
     spec:
       containers:
-      - image: edgehub/deviceshifu-http:v0.0.1
+      - image: edgehub/deviceshifu-http-http:v0.0.1
         name: deviceshifu-http
         ports:
         - containerPort: 8080

--- a/docs/design/design-shifuController-zh.md
+++ b/docs/design/design-shifuController-zh.md
@@ -136,7 +136,7 @@ spec:
         app: edgedevice-thermometer-deployment
     spec:
       containers:
-      - image: edgehub/deviceshifu-http:v0.0.1
+      - image: edgehub/deviceshifu-http-http:v0.0.1
         name: deviceshifu-http
         ports:
         - containerPort: 8080

--- a/docs/design/design-shifuController.md
+++ b/docs/design/design-shifuController.md
@@ -136,7 +136,7 @@ spec:
         app: edgedevice-thermometer-deployment
     spec:
       containers:
-      - image: edgehub/deviceshifu-http:v0.0.1
+      - image: edgehub/deviceshifu-http-http:v0.0.1
         name: deviceshifu-http
         ports:
         - containerPort: 8080

--- a/docs/guide/hello-world-device/configuration/deviceshifu-helloworld-deployment.yaml
+++ b/docs/guide/hello-world-device/configuration/deviceshifu-helloworld-deployment.yaml
@@ -16,7 +16,7 @@ spec:
         app: edgedevice-helloworld-deployment
     spec:
       containers:
-        - image: edgehub/deviceshifu-http:v0.0.1
+        - image: edgehub/deviceshifu-http-http:v0.0.1
           name: deviceshifu-http
           ports:
             - containerPort: 8080

--- a/examples/rtspDeviceShifu/camera-deployment/deviceshifu-camera-deployment.yaml
+++ b/examples/rtspDeviceShifu/camera-deployment/deviceshifu-camera-deployment.yaml
@@ -16,7 +16,7 @@ spec:
         app: edgedevice-camera-deployment
     spec:
       containers:
-      - image: edgehub/deviceshifu-http-multi:v0.0.1
+      - image: edgehub/deviceshifu-http-http:v0.0.1
         name: deviceshifu-http
         ports:
         - containerPort: 8080

--- a/examples/siemensPLCDeviceShifu/plc-deployment/plc-deviceshifu-deployment.yaml
+++ b/examples/siemensPLCDeviceShifu/plc-deployment/plc-deviceshifu-deployment.yaml
@@ -16,7 +16,7 @@ spec:
         app: edgedevice-plc-deployment
     spec:
       containers:
-        - image: edgehub/deviceshifu-http-multi:v0.0.1
+        - image: edgehub/deviceshifu-http-http:v0.0.1
           name: deviceshifu-http
           ports:
             - containerPort: 8080

--- a/test/scripts/deviceshifu-setup.sh
+++ b/test/scripts/deviceshifu-setup.sh
@@ -16,7 +16,7 @@ if [ "$1" == "apply" ] || [ "$1" == "delete" ]; then
                 kind load docker-image edgehub/mockdevice-plate-reader:v0.0.1
                 kind load docker-image edgehub/mockdevice-robot-arm:v0.0.1
                 kind load docker-image edgehub/mockdevice-thermometer:v0.0.1
-                kind load docker-image edgehub/deviceshifu-http:v0.0.1
+                kind load docker-image edgehub/deviceshifu-http-http:v0.0.1
                 kind load docker-image edgehub/edgedevice-controller:v0.0.1
                 kubectl apply -f k8s/crd
                 kubectl create ns devices
@@ -27,7 +27,7 @@ if [ "$1" == "apply" ] || [ "$1" == "delete" ]; then
         else
                 kind delete cluster
                 docker rmi $(docker images | grep 'edgehub/mockdevice' | awk '{print $3}')
-                docker rmi $(docker images | grep 'edgehub/deviceshifu-http' | awk '{print $3}')
+                docker rmi $(docker images | grep 'edgehub/deviceshifu-http-http' | awk '{print $3}')
                 docker rmi $(docker images | grep 'edgehub/edgedevice-controller' | awk '{print $3}')
                 docker rmi quay.io/brancz/kube-rbac-proxy:v0.8.0
                 docker rmi $(docker images | grep 'kindest/node' | awk '{print $3}')


### PR DESCRIPTION
…ttp-http:v0.0.1'

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
This PR unifies all containers that uses HTTP2HTTP

**Will this PR make the community happier**? 
Yes

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #93 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
- update all occurrences of http to http deviceShifu to "edgehub/deviceshifu-http-http:v0.0.1"
```
