### PR TITLE
Bump up Kustomize, controller-gen and kube-rbac-proxy versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,13 +62,13 @@ download-demo-files:
 	docker pull edgehub/mockdevice-thermometer:${IMAGE_VERSION}
 	docker pull edgehub/deviceshifu-http-http:${IMAGE_VERSION}
 	docker pull edgehub/edgedevice-controller-multi:${IMAGE_VERSION}
-	docker pull quay.io/brancz/kube-rbac-proxy:v0.8.0
+	docker pull quay.io/brancz/kube-rbac-proxy:v0.12.0
 	docker pull kindest/node:v1.23.4@sha256:0e34f0d0fd448aa2f2819cfd74e99fe5793a6e4938b328f657c8e3f81ee0dfb9
 	docker pull nginx:1.21
 
 compress-demo-files:
 	mkdir -p build_dir
-	docker save quay.io/brancz/kube-rbac-proxy:v0.8.0 | gzip > build_dir/kube-rbac-proxy.tar.gz
+	docker save quay.io/brancz/kube-rbac-proxy:v0.12.0 | gzip > build_dir/kube-rbac-proxy.tar.gz
 	docker save edgehub/mockdevice-agv:${IMAGE_VERSION} | gzip > build_dir/mockdevice-agv.tar.gz
 	docker save edgehub/mockdevice-plate-reader:${IMAGE_VERSION} | gzip > build_dir/mockdevice-plate-reader.tar.gz
 	docker save edgehub/mockdevice-robot-arm:${IMAGE_VERSION} | gzip > build_dir/mockdevice-robot-arm.tar.gz

--- a/go.mod
+++ b/go.mod
@@ -45,7 +45,7 @@ require (
 	k8s.io/api v0.24.2 // indirect
 	k8s.io/klog/v2 v2.60.1 // indirect
 	k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9 // indirect
-	sigs.k8s.io/controller-runtime v0.12.1 // indirect
+	sigs.k8s.io/controller-runtime v0.12.2 // indirect
 	sigs.k8s.io/json v0.0.0-20211208200746-9f7c6b3444d2 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.1 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1125,6 +1125,7 @@ sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.22/go.mod h1:LEScyz
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.30/go.mod h1:fEO7lRTdivWO2qYVCVG7dEADOMo/MLDCVr8So2g88Uw=
 sigs.k8s.io/controller-runtime v0.12.1 h1:4BJY01xe9zKQti8oRjj/NeHKRXthf1YkYJAgLONFFoI=
 sigs.k8s.io/controller-runtime v0.12.1/go.mod h1:BKhxlA4l7FPK4AQcsuL4X6vZeWnKDXez/vp1Y8dxTU0=
+sigs.k8s.io/controller-runtime v0.12.2/go.mod h1:qKsk4WE6zW2Hfj0G4v10EnNB2jMG1C+NTb8h+DwCoU0=
 sigs.k8s.io/json v0.0.0-20211208200746-9f7c6b3444d2 h1:kDi4JBNAsJWfz1aEXhO8Jg87JJaPNLh5tIzYHgStQ9Y=
 sigs.k8s.io/json v0.0.0-20211208200746-9f7c6b3444d2/go.mod h1:B+TnT182UBxE84DiCz4CVE26eOSDAeYCpfDnC2kdKMY=
 sigs.k8s.io/structured-merge-diff/v4 v4.0.2/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=

--- a/k8s/crd/Makefile
+++ b/k8s/crd/Makefile
@@ -2,7 +2,7 @@
 # Image URL to use all building/pushing image targets
 IMG ?= controller:latest
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
-CRD_OPTIONS ?= "crd:trivialVersions=true,preserveUnknownFields=false"
+CRD_OPTIONS ?= "crd"
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -111,11 +111,11 @@ undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/confi
 
 CONTROLLER_GEN = $(shell pwd)/bin/controller-gen
 controller-gen: ## Download controller-gen locally if necessary.
-	$(call go-get-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.4.1)
+	$(call go-get-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.9.0)
 
 KUSTOMIZE = $(shell pwd)/bin/kustomize
 kustomize: ## Download kustomize locally if necessary.
-	$(call go-get-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v3@v3.8.7)
+	$(call go-get-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v4)
 
 # go-get-tool will 'go get' any package $2 and install it to $1.
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))

--- a/k8s/crd/config/crd/bases/shifu.edgenesis.io_edgedevices.yaml
+++ b/k8s/crd/config/crd/bases/shifu.edgenesis.io_edgedevices.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.9.0
   creationTimestamp: null
   name: edgedevices.shifu.edgenesis.io
 spec:
@@ -105,9 +104,3 @@ spec:
         type: object
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/k8s/crd/config/default/manager_auth_proxy_patch.yaml
+++ b/k8s/crd/config/default/manager_auth_proxy_patch.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: quay.io/brancz/kube-rbac-proxy:v0.8.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.12.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/k8s/crd/config/rbac/role.yaml
+++ b/k8s/crd/config/rbac/role.yaml
@@ -1,4 +1,3 @@
-
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/k8s/crd/install/config_crd.yaml
+++ b/k8s/crd/install/config_crd.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.9.0
   creationTimestamp: null
   name: edgedevices.shifu.edgenesis.io
 spec:
@@ -20,10 +20,14 @@ spec:
         description: EdgeDevice is the Schema for the edgedevices API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -33,7 +37,8 @@ spec:
               address:
                 type: string
               connection:
-                description: Connection specifies the EdgeDevice-EdgeNode connection type.
+                description: Connection specifies the EdgeDevice-EdgeNode connection
+                  type.
                 type: string
               customMetadata:
                 additionalProperties:
@@ -43,10 +48,12 @@ spec:
                 description: Protocol specifies the EdgeDevice's communication protocol.
                 type: string
               protocolSettings:
-                description: ProtocolSettings defines protocol settings when connecting to an EdgeDevice
+                description: ProtocolSettings defines protocol settings when connecting
+                  to an EdgeDevice
                 properties:
                   MQTTSetting:
-                    description: MQTTSetting defines MQTT specific settings when connecting to an EdgeDevice
+                    description: MQTTSetting defines MQTT specific settings when connecting
+                      to an EdgeDevice
                     properties:
                       MQTTServerAddress:
                         type: string
@@ -56,7 +63,8 @@ spec:
                         type: string
                     type: object
                   OPCUASetting:
-                    description: OPCUASetting defines OPC UA specific settings when connecting to an OPC UA endpoint
+                    description: OPCUASetting defines OPC UA specific settings when
+                      connecting to an OPC UA endpoint
                     properties:
                       ConnectionTimeoutInMilliseconds:
                         format: int64
@@ -71,7 +79,8 @@ spec:
                         type: string
                     type: object
                   SocketSetting:
-                    description: SocketSetting defines Socket specific settings when connecting to an EdgeDevice
+                    description: SocketSetting defines Socket specific settings when
+                      connecting to an EdgeDevice
                     properties:
                       encoding:
                         type: string
@@ -87,15 +96,10 @@ spec:
             description: EdgeDeviceStatus defines the observed state of EdgeDevice
             properties:
               edgedevicephase:
-                description: EdgeDevicePhase is a simple, high-level summary of where the EdgeDevice is in its lifecycle.
+                description: EdgeDevicePhase is a simple, high-level summary of where
+                  the EdgeDevice is in its lifecycle.
                 type: string
             type: object
         type: object
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/k8s/crd/install/config_default.yaml
+++ b/k8s/crd/install/config_default.yaml
@@ -9,7 +9,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.9.0
   creationTimestamp: null
   name: edgedevices.shifu.edgenesis.io
 spec:
@@ -27,10 +27,14 @@ spec:
         description: EdgeDevice is the Schema for the edgedevices API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -40,7 +44,8 @@ spec:
               address:
                 type: string
               connection:
-                description: Connection specifies the EdgeDevice-EdgeNode connection type.
+                description: Connection specifies the EdgeDevice-EdgeNode connection
+                  type.
                 type: string
               customMetadata:
                 additionalProperties:
@@ -50,10 +55,12 @@ spec:
                 description: Protocol specifies the EdgeDevice's communication protocol.
                 type: string
               protocolSettings:
-                description: ProtocolSettings defines protocol settings when connecting to an EdgeDevice
+                description: ProtocolSettings defines protocol settings when connecting
+                  to an EdgeDevice
                 properties:
                   MQTTSetting:
-                    description: MQTTSetting defines MQTT specific settings when connecting to an EdgeDevice
+                    description: MQTTSetting defines MQTT specific settings when connecting
+                      to an EdgeDevice
                     properties:
                       MQTTServerAddress:
                         type: string
@@ -63,7 +70,8 @@ spec:
                         type: string
                     type: object
                   OPCUASetting:
-                    description: OPCUASetting defines OPC UA specific settings when connecting to an OPC UA endpoint
+                    description: OPCUASetting defines OPC UA specific settings when
+                      connecting to an OPC UA endpoint
                     properties:
                       ConnectionTimeoutInMilliseconds:
                         format: int64
@@ -78,7 +86,8 @@ spec:
                         type: string
                     type: object
                   SocketSetting:
-                    description: SocketSetting defines Socket specific settings when connecting to an EdgeDevice
+                    description: SocketSetting defines Socket specific settings when
+                      connecting to an EdgeDevice
                     properties:
                       encoding:
                         type: string
@@ -94,18 +103,13 @@ spec:
             description: EdgeDeviceStatus defines the observed state of EdgeDevice
             properties:
               edgedevicephase:
-                description: EdgeDevicePhase is a simple, high-level summary of where the EdgeDevice is in its lifecycle.
+                description: EdgeDevicePhase is a simple, high-level summary of where
+                  the EdgeDevice is in its lifecycle.
                 type: string
             type: object
         type: object
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -309,7 +313,7 @@ spec:
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
         - --v=10
-        image: quay.io/brancz/kube-rbac-proxy:v0.8.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.12.0
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443

--- a/k8s/crd/install/shifu_install.yml
+++ b/k8s/crd/install/shifu_install.yml
@@ -9,7 +9,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.9.0
   creationTimestamp: null
   name: edgedevices.shifu.edgenesis.io
 spec:
@@ -27,10 +27,14 @@ spec:
         description: EdgeDevice is the Schema for the edgedevices API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -40,7 +44,8 @@ spec:
               address:
                 type: string
               connection:
-                description: Connection specifies the EdgeDevice-EdgeNode connection type.
+                description: Connection specifies the EdgeDevice-EdgeNode connection
+                  type.
                 type: string
               customMetadata:
                 additionalProperties:
@@ -50,10 +55,12 @@ spec:
                 description: Protocol specifies the EdgeDevice's communication protocol.
                 type: string
               protocolSettings:
-                description: ProtocolSettings defines protocol settings when connecting to an EdgeDevice
+                description: ProtocolSettings defines protocol settings when connecting
+                  to an EdgeDevice
                 properties:
                   MQTTSetting:
-                    description: MQTTSetting defines MQTT specific settings when connecting to an EdgeDevice
+                    description: MQTTSetting defines MQTT specific settings when connecting
+                      to an EdgeDevice
                     properties:
                       MQTTServerAddress:
                         type: string
@@ -63,7 +70,8 @@ spec:
                         type: string
                     type: object
                   OPCUASetting:
-                    description: OPCUASetting defines OPC UA specific settings when connecting to an OPC UA endpoint
+                    description: OPCUASetting defines OPC UA specific settings when
+                      connecting to an OPC UA endpoint
                     properties:
                       ConnectionTimeoutInMilliseconds:
                         format: int64
@@ -78,7 +86,8 @@ spec:
                         type: string
                     type: object
                   SocketSetting:
-                    description: SocketSetting defines Socket specific settings when connecting to an EdgeDevice
+                    description: SocketSetting defines Socket specific settings when
+                      connecting to an EdgeDevice
                     properties:
                       encoding:
                         type: string
@@ -94,18 +103,13 @@ spec:
             description: EdgeDeviceStatus defines the observed state of EdgeDevice
             properties:
               edgedevicephase:
-                description: EdgeDevicePhase is a simple, high-level summary of where the EdgeDevice is in its lifecycle.
+                description: EdgeDevicePhase is a simple, high-level summary of where
+                  the EdgeDevice is in its lifecycle.
                 type: string
             type: object
         type: object
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -309,7 +313,7 @@ spec:
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
         - --v=10
-        image: quay.io/brancz/kube-rbac-proxy:v0.8.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.12.0
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443
@@ -352,11 +356,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: devices
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: deviceshifu
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/test/scripts/deviceshifu-setup.sh
+++ b/test/scripts/deviceshifu-setup.sh
@@ -11,7 +11,7 @@ if [ "$1" == "apply" ] || [ "$1" == "delete" ]; then
                 (cd /build_dir && for f in *.tar.gz; do docker load < $f; done)
                 kind delete cluster && kind create cluster
                 kind load docker-image nginx:1.21
-                kind load docker-image quay.io/brancz/kube-rbac-proxy:v0.8.0
+                kind load docker-image quay.io/brancz/kube-rbac-proxy:v0.12.0
                 kind load docker-image edgehub/mockdevice-agv:v0.0.1
                 kind load docker-image edgehub/mockdevice-plate-reader:v0.0.1
                 kind load docker-image edgehub/mockdevice-robot-arm:v0.0.1
@@ -24,7 +24,7 @@ if [ "$1" == "apply" ] || [ "$1" == "delete" ]; then
                 docker rmi $(docker images | grep 'edgehub/mockdevice' | awk '{print $3}')
                 docker rmi $(docker images | grep 'edgehub/deviceshifu-http-http' | awk '{print $3}')
                 docker rmi $(docker images | grep 'edgehub/edgedevice-controller' | awk '{print $3}')
-                docker rmi quay.io/brancz/kube-rbac-proxy:v0.8.0
+                docker rmi quay.io/brancz/kube-rbac-proxy:v0.12.0
                 docker rmi $(docker images | grep 'kindest/node' | awk '{print $3}')
                 docker rmi nginx:1.21
         fi

--- a/test/scripts/kind-load-image.sh
+++ b/test/scripts/kind-load-image.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-IMAGE_TO_BE_LOADED=( quay.io/brancz/kube-rbac-proxy/kube-rbac-proxy:v0.8.0 edgehub/edgedevice-controller:v0.0.1)
+IMAGE_TO_BE_LOADED=(quay.io/brancz/kube-rbac-proxy/kube-rbac-proxy:v0.12.0 edgehub/edgedevice-controller:v0.0.1)
 
 for img in "${IMAGE_TO_BE_LOADED[@]}"; do
     docker pull $img


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:'
This PR updates crd related packages' version to a more recent one

**Will this PR make the community happier**? 
Yes

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
- Bump up kube-rbac-proxy version from v0.8.0 to v0.12.0
- Bump up Kustomize verion from v3.8.7 to v4
- Bump up controller-gen from v0.4.1 to v0.9.0
- Updated scripts that uses kube-rbac-proxy
- regenerate install YAMLs
```
