### PR TITLE
fix #202: camera stops streaming without timeout

### DIFF
--- a/examples/rtspDeviceShifu/camera-deployment/deviceshifu-camera-configmap.yaml
+++ b/examples/rtspDeviceShifu/camera-deployment/deviceshifu-camera-configmap.yaml
@@ -9,6 +9,8 @@ data:
     driverImage: edgenesis/camera-python:v0.0.1
   instructions: |
     instructions:
+    instructionSettings:
+      defaultTimeoutSeconds: 0
       capture:
       info:
       stream:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: Fix example.

**Will this PR make the community happier**? Yes.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #202

**Note**: rtsp camera works on the latest build (build the concerning image by yourself). Provided v0.0.5 not works well currently.
