### PR TITLE
Use gcr distroless instead of edgehub's image

### DIFF
--- a/dockerfiles/Dockerfile.deviceshifuHTTP
+++ b/dockerfiles/Dockerfile.deviceshifuHTTP
@@ -21,7 +21,7 @@ ARG TARGETARCH
 
 RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -a -o /output/deviceshifu cmd/deviceshifu/cmdHTTP/main.go
 
-FROM edgehub/distroless-static:nonroot
+FROM gcr.io/distroless/static-debian11
 WORKDIR /
 COPY --from=builder /output/deviceshifu deviceshifu
 

--- a/dockerfiles/Dockerfile.deviceshifuHTTP
+++ b/dockerfiles/Dockerfile.deviceshifuHTTP
@@ -3,7 +3,6 @@ FROM --platform=$BUILDPLATFORM golang:1.18.4 as builder
 
 WORKDIR /shifu
 
-ENV GOPROXY=https://goproxy.cn,direct
 ENV GO111MODULE=on
 ENV GOPRIVATE=github.com/Edgenesis
 

--- a/dockerfiles/Dockerfile.deviceshifuMQTT
+++ b/dockerfiles/Dockerfile.deviceshifuMQTT
@@ -21,7 +21,7 @@ ARG TARGETARCH
 
 RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -a -o /output/deviceshifu cmd/deviceshifu/cmdMQTT/main.go
 
-FROM edgehub/distroless-static:nonroot
+FROM gcr.io/distroless/static-debian11
 WORKDIR /
 COPY --from=builder /output/deviceshifu deviceshifu
 

--- a/dockerfiles/Dockerfile.deviceshifuMQTT
+++ b/dockerfiles/Dockerfile.deviceshifuMQTT
@@ -3,7 +3,6 @@ FROM --platform=$BUILDPLATFORM golang:1.18.4 as builder
 
 WORKDIR /shifu
 
-ENV GOPROXY=https://goproxy.cn,direct
 ENV GO111MODULE=on
 ENV GOPRIVATE=github.com/Edgenesis
 

--- a/dockerfiles/Dockerfile.deviceshifuOPCUA
+++ b/dockerfiles/Dockerfile.deviceshifuOPCUA
@@ -3,7 +3,6 @@ FROM --platform=$BUILDPLATFORM golang:1.18.4 as builder
 
 WORKDIR /shifu
 
-ENV GOPROXY=https://goproxy.cn,direct
 ENV GO111MODULE=on
 ENV GOPRIVATE=github.com/Edgenesis
 

--- a/dockerfiles/Dockerfile.deviceshifuOPCUA
+++ b/dockerfiles/Dockerfile.deviceshifuOPCUA
@@ -21,7 +21,7 @@ ARG TARGETARCH
 
 RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -a -o /output/deviceshifu cmd/deviceshifu/cmdOPCUA/main.go
 
-FROM edgehub/distroless-static:nonroot
+FROM gcr.io/distroless/static-debian11
 WORKDIR /
 COPY --from=builder /output/deviceshifu deviceshifu
 

--- a/dockerfiles/Dockerfile.deviceshifuSocket
+++ b/dockerfiles/Dockerfile.deviceshifuSocket
@@ -21,7 +21,7 @@ ARG TARGETARCH
 
 RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -a -o /output/deviceshifu cmd/deviceshifu/cmdSocket/main.go
 
-FROM edgehub/distroless-static:nonroot
+FROM gcr.io/distroless/static-debian11
 WORKDIR /
 COPY --from=builder /output/deviceshifu deviceshifu
 

--- a/dockerfiles/Dockerfile.deviceshifuSocket
+++ b/dockerfiles/Dockerfile.deviceshifuSocket
@@ -3,7 +3,6 @@ FROM --platform=$BUILDPLATFORM golang:1.18.4 as builder
 
 WORKDIR /shifu
 
-ENV GOPROXY=https://goproxy.cn,direct
 ENV GO111MODULE=on
 ENV GOPRIVATE=github.com/Edgenesis
 

--- a/pkg/k8s/crd/Dockerfile
+++ b/pkg/k8s/crd/Dockerfile
@@ -26,7 +26,7 @@ RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -a -o manager main.
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM edgehub/distroless-static:nonroot
+FROM gcr.io/distroless/static-debian11
 WORKDIR /
 COPY --from=builder /workspace/manager .
 USER 65532:65532

--- a/pkg/k8s/crd/Dockerfile
+++ b/pkg/k8s/crd/Dockerfile
@@ -1,7 +1,6 @@
 # Build the manager binary
 FROM --platform=$BUILDPLATFORM golang:1.18.4 as builder
 
-ENV GOPROXY=https://goproxy.cn,direct
 ENV GO111MODULE=on
 ENV GOPRIVATE=github.com/Edgenesis
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
Change distroless container from edgehub's to gcr's
**Will this PR make the community happier**? 
yes
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
