### PR TITLE
Bump up Go version to 1.19.1

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,32 +1,7 @@
-# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.194.0/containers/go/.devcontainer/base.Dockerfile
+# See here for image contents: https://github.com/Edgenesis/devcontainer-go
 
 ARG VARIANT="latest"
-FROM edgehub/go-dev:${VARIANT}
+FROM edgehub/devcontainer-go:${VARIANT}
 
-ARG KIND_VERSION="v0.14.0"
-
-ENV GOPROXY=https://goproxy.cn,direct
-ENV GOPRIVATE=github.com/Edgenesis,edgenesis.io/shifu
-ENV GO111MODULE=on
-
-# [Optional] Uncomment this section to install additional OS packages.
-RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-     && apt-get -y install --no-install-recommends lsof apt-transport-https ca-certificates curl gnupg2 lsb-release \
-     && curl -fsSL https://download.docker.com/linux/$(lsb_release -is | tr '[:upper:]' '[:lower:]')/gpg | apt-key add - 2>/dev/null \
-     && echo "deb [arch=$(go env GOARCH)] https://download.docker.com/linux/$(lsb_release -is | tr '[:upper:]' '[:lower:]') $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list \
-     && apt-get update \
-     && apt-get install -y docker-ce-cli
-
-RUN curl -Lo ./kind https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-linux-$(go env GOARCH) \
-     && chmod +x ./kind \
-     && mv ./kind /usr/local/bin/kind
-
-RUN curl -Lo ./kubebuilder https://go.kubebuilder.io/dl/latest/$(go env GOOS)/$(go env GOARCH) \
-     && chmod +x ./kubebuilder \ 
-     && mv ./kubebuilder /usr/local/bin/kubebuilder
-
-# [Optional] Uncomment the next line to use go get to install anything else you need
-RUN go install golang.org/x/tools/gopls@latest
-
-# [Optional] Uncomment this line to install global node packages.
-# RUN su vscode -c "source /usr/local/share/nvm/nvm.sh && npm install -g <your-package-here>" 2>&1
+RUN echo "source /etc/bash_completion" >> "/root/.bashrc"
+RUN echo "source <(kubectl completion bash)" >> "/root/.bashrc"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,48 +1,43 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
-// https://github.com/microsoft/vscode-dev-containers/tree/v0.194.0/containers/go
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.241.1/containers/go
 {
 	"name": "Go",
 	"build": {
 		"dockerfile": "Dockerfile",
 		"args": {
-			// Update the VARIANT arg to pick a version of Go: 1, 1.16, 1.17
-			"VARIANT": "latest",
-			// Options
-			"NODE_VERSION": "lts/*"
+			"VARIANT": "latest"
 		}
 	},
-	"runArgs": [ 
-		"--cap-add=SYS_PTRACE",
+	"runArgs": [
+		"--cap-add=SYS_PTRACE", 
 		"--security-opt",
 		"seccomp=unconfined",
 		"--init",
-		"--network=host" // host networking
+		"--network=host",
+		"--privileged"
 	],
-	// Enable docker-in-docker
-	"mounts": [ "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind" ],
+	// Enable docker-from-docker
+	"mounts": [ "source=/var/run/docker.sock,target=/var/run/docker-host.sock,type=bind" ],
 
-	// Set *default* container specific settings.json values on container create.
-	"settings": {
-		"go.toolsManagement.checkForUpdates": "local",
-		"go.useLanguageServer": true,
-		"go.gopath": "/go",
-		"go.goroot": "/usr/local/go"
-	},
-
-	// Add the IDs of extensions you want installed when the container is created.
-	"extensions": [
-		"golang.Go",
-		// "lfs.vscode-emacs-friendly," Emacs Friendly Keymap
-		"eamodio.gitlens",
-		"ms-kubernetes-tools.vscode-kubernetes-tools"
-	],
-
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [],
-
-	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "go mod download && cd k8s/crd && go mod download"
-
-	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
-	// "remoteUser": "vscode"
+	// Configure tool-specific properties.
+	"customizations": {
+		// Configure properties specific to VS Code.
+		"vscode": {
+			// Set *default* container specific settings.json values on container create.
+			"settings": { 
+				"go.toolsManagement.checkForUpdates": "local",
+				"go.useLanguageServer": true,
+				"go.gopath": "/go"
+			},
+			
+			// Add the IDs of extensions you want installed when the container is created.
+			"extensions": [
+				"davidanson.vscode-markdownlint",
+				"golang.Go",
+				"ms-azuretools.vscode-dapr",
+				"ms-azuretools.vscode-docker",
+				"ms-kubernetes-tools.vscode-kubernetes-tools"
+			]
+		}
+	}
 }

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.18'
+          go-version: '1.19'
       - name: Run coverage
         run: make test
       - name: Codecov

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: 1.19
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3

--- a/azure-pipelines/azure-pipelines.yml
+++ b/azure-pipelines/azure-pipelines.yml
@@ -44,7 +44,7 @@ stages:
     steps:
       - task: GoTool@0
         inputs:
-          version: '1.18.4'
+          version: '1.19.1'
       - task: Go@0
         displayName: "go get"
         inputs:
@@ -111,7 +111,7 @@ stages:
     steps:
       - task: GoTool@0
         inputs:
-          version: '1.18.4'
+          version: '1.19.1'
       - task: Go@0
         displayName: "go get"
         inputs:

--- a/cmd/httpstub/powershellstub/powershellstub.go
+++ b/cmd/httpstub/powershellstub/powershellstub.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"os/exec"
@@ -66,7 +66,7 @@ func httpCmdlinePostHandler(resp http.ResponseWriter, req *http.Request) {
 		}
 	}
 
-	httpCommand, err := ioutil.ReadAll(req.Body)
+	httpCommand, err := io.ReadAll(req.Body)
 	if err != nil {
 		klog.Fatal(err)
 	}
@@ -104,7 +104,7 @@ func httpHealthHandler(resp http.ResponseWriter, req *http.Request) {
 }
 
 func httpFileServeHandler(resp http.ResponseWriter, req *http.Request) {
-	httpFileLocation, err := ioutil.ReadAll(req.Body)
+	httpFileLocation, err := io.ReadAll(req.Body)
 	if err != nil {
 		panic(err)
 	}
@@ -114,7 +114,7 @@ func httpFileServeHandler(resp http.ResponseWriter, req *http.Request) {
 	klog.Infof("File to open: %v", fileLocationString)
 
 	if _, err := os.Stat(fileLocationString); err == nil {
-		fileBytes, err := ioutil.ReadFile(fileLocationString)
+		fileBytes, err := os.ReadFile(fileLocationString)
 		if err != nil {
 			panic(err)
 		}

--- a/cmd/httpstub/sshstub/sshstub.go
+++ b/cmd/httpstub/sshstub/sshstub.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"os"
@@ -42,7 +42,7 @@ func init() {
 }
 
 func main() {
-	key, err := ioutil.ReadFile(privateSSHKeyFile)
+	key, err := os.ReadFile(privateSSHKeyFile)
 	if err != nil {
 		klog.Fatalf("unable to read private key: %v", err)
 	}
@@ -92,7 +92,7 @@ func httpCmdlinePostHandler(sshConnection *ssh.Client) http.HandlerFunc {
 		}
 
 		defer session.Close()
-		httpCommand, err := ioutil.ReadAll(req.Body)
+		httpCommand, err := io.ReadAll(req.Body)
 		if err != nil {
 			panic(err)
 		}

--- a/dockerfiles/Dockerfile.deviceshifuHTTP
+++ b/dockerfiles/Dockerfile.deviceshifuHTTP
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM golang:1.18.4 as builder
+FROM --platform=$BUILDPLATFORM golang:1.19 as builder
 
 WORKDIR /shifu
 

--- a/dockerfiles/Dockerfile.deviceshifuOPCUA
+++ b/dockerfiles/Dockerfile.deviceshifuOPCUA
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM golang:1.18.4 as builder
+FROM --platform=$BUILDPLATFORM golang:1.19 as builder
 
 WORKDIR /shifu
 

--- a/dockerfiles/Dockerfile.deviceshifuSocket
+++ b/dockerfiles/Dockerfile.deviceshifuSocket
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM golang:1.18.4 as builder
+FROM --platform=$BUILDPLATFORM golang:1.19 as builder
 
 WORKDIR /shifu
 

--- a/examples/deviceshifu/hello-world-device/Dockerfile
+++ b/examples/deviceshifu/hello-world-device/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM golang:1.18-alpine
+FROM golang:1.19-alpine
 WORKDIR /app
 COPY go.mod ./
 RUN go mod download

--- a/examples/deviceshifu/high-temperature-detector-application/Dockerfile
+++ b/examples/deviceshifu/high-temperature-detector-application/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM golang:1.18-alpine
+FROM golang:1.19-alpine
 WORKDIR /app
 COPY go.mod ./
 RUN go mod download

--- a/examples/deviceshifu/mockdevice/agv/Dockerfile.mockdevice-agv
+++ b/examples/deviceshifu/mockdevice/agv/Dockerfile.mockdevice-agv
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM golang:1.18.4 as builder
+FROM --platform=$BUILDPLATFORM golang:1.19 as builder
 
 WORKDIR /shifu
 

--- a/examples/deviceshifu/mockdevice/plate-reader/Dockerfile.mockdevice-plate-reader
+++ b/examples/deviceshifu/mockdevice/plate-reader/Dockerfile.mockdevice-plate-reader
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM golang:1.18.4 as builder
+FROM --platform=$BUILDPLATFORM golang:1.19 as builder
 
 WORKDIR /shifu
 

--- a/examples/deviceshifu/mockdevice/plc/Dockerfile.mockdevice-plc
+++ b/examples/deviceshifu/mockdevice/plc/Dockerfile.mockdevice-plc
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM golang:1.18.4 as builder
+FROM --platform=$BUILDPLATFORM golang:1.19 as builder
 
 WORKDIR /shifu
 

--- a/examples/deviceshifu/mockdevice/robot-arm/Dockerfile.mockdevice-robot-arm
+++ b/examples/deviceshifu/mockdevice/robot-arm/Dockerfile.mockdevice-robot-arm
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM golang:1.18.4 as builder
+FROM --platform=$BUILDPLATFORM golang:1.19 as builder
 
 WORKDIR /shifu
 

--- a/examples/deviceshifu/mockdevice/socket/Dockerfile.mockdevice-socket
+++ b/examples/deviceshifu/mockdevice/socket/Dockerfile.mockdevice-socket
@@ -1,4 +1,4 @@
-FROM golang:1.18-alpine
+FROM golang:1.19-alpine
 
 WORKDIR /worker
 

--- a/examples/deviceshifu/mockdevice/thermometer/Dockerfile.mockdevice-thermometer
+++ b/examples/deviceshifu/mockdevice/thermometer/Dockerfile.mockdevice-thermometer
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM golang:1.18.4 as builder
+FROM --platform=$BUILDPLATFORM golang:1.19 as builder
 
 WORKDIR /shifu
 

--- a/examples/driver_utils/simple-alpine/Dockerfile.sample
+++ b/examples/driver_utils/simple-alpine/Dockerfile.sample
@@ -1,4 +1,4 @@
-FROM golang:1.18.4 as builder
+FROM golang:1.19 as builder
 
 WORKDIR /
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/edgenesis/shifu
 
-go 1.18
+go 1.19
 
 require (
 	github.com/eclipse/paho.mqtt.golang v1.4.1

--- a/pkg/deviceshifu/deviceshifuhttp/deviceshifuhttpconfig_test.go
+++ b/pkg/deviceshifu/deviceshifuhttp/deviceshifuhttpconfig_test.go
@@ -1,7 +1,6 @@
 package deviceshifuhttp
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"reflect"
@@ -133,7 +132,7 @@ func TestNewDeviceShifuConfig(t *testing.T) {
 }
 
 func GenerateConfigMapFromSnippet(fileName string, folder string) error {
-	snippetFile, err := ioutil.ReadFile(fileName)
+	snippetFile, err := os.ReadFile(fileName)
 	if err != nil {
 		return err
 	}

--- a/pkg/deviceshifu/deviceshifumqtt/deviceshifumqttconfig_test.go
+++ b/pkg/deviceshifu/deviceshifumqtt/deviceshifumqttconfig_test.go
@@ -1,7 +1,6 @@
 package deviceshifumqtt
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"reflect"
@@ -89,7 +88,7 @@ func TestNewDeviceShifuConfig(t *testing.T) {
 }
 
 func GenerateConfigMapFromSnippet(fileName string, folder string) error {
-	snippetFile, err := ioutil.ReadFile(fileName)
+	snippetFile, err := os.ReadFile(fileName)
 	if err != nil {
 		return err
 	}

--- a/pkg/deviceshifu/deviceshifuopcua/deviceshifuopcuaconfig.go
+++ b/pkg/deviceshifu/deviceshifuopcua/deviceshifuopcuaconfig.go
@@ -5,8 +5,7 @@ import (
 )
 
 const (
-	opcuaInstructionsStr = "opcuaInstructions"
-	opcuaID              = "OPCUANodeID"
+	opcuaID = "OPCUANodeID"
 )
 
 // OPCUAInstructions OPCUA Instructions

--- a/pkg/deviceshifu/deviceshifuopcua/deviceshifuopcuaconfig_test.go
+++ b/pkg/deviceshifu/deviceshifuopcua/deviceshifuopcuaconfig_test.go
@@ -1,7 +1,6 @@
 package deviceshifuopcua
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"reflect"
@@ -105,7 +104,7 @@ func TestNewDeviceShifuConfig(t *testing.T) {
 }
 
 func GenerateConfigMapFromSnippet(fileName string, folder string) error {
-	snippetFile, err := ioutil.ReadFile(fileName)
+	snippetFile, err := os.ReadFile(fileName)
 	if err != nil {
 		return err
 	}

--- a/pkg/deviceshifu/deviceshifusocket/deviceshifusocketconfig_test.go
+++ b/pkg/deviceshifu/deviceshifusocket/deviceshifusocketconfig_test.go
@@ -1,7 +1,6 @@
 package deviceshifusocket
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"reflect"
@@ -86,7 +85,7 @@ func TestNewDeviceShifuConfig(t *testing.T) {
 }
 
 func GenerateConfigMapFromSnippet(fileName string, folder string) error {
-	snippetFile, err := ioutil.ReadFile(fileName)
+	snippetFile, err := os.ReadFile(fileName)
 	if err != nil {
 		return err
 	}

--- a/pkg/k8s/crd/Dockerfile
+++ b/pkg/k8s/crd/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM golang:1.18.4 as builder
+FROM --platform=$BUILDPLATFORM golang:1.19 as builder
 
 ENV GO111MODULE=on
 ENV GOPRIVATE=github.com/Edgenesis


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
This PR updates Shifu's Golang version to 1.19.1

**Will this PR make the community happier**? 
Yes

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**How is this PR tested**
- [ ] unit test
- [x] e2e test
- [ ] other (please specify)
will be tested in E2E

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
- updates go.mod
- updates all Dockerfile to use Go 1.19
- update devcontainer
```
