### PR TITLE
fix negative instruction timeout

### DIFF
--- a/pkg/deviceshifu/deviceshifubase/deviceshifubase.go
+++ b/pkg/deviceshifu/deviceshifubase/deviceshifubase.go
@@ -59,7 +59,7 @@ const (
 	DeviceNameSpaceDefault                   string = "default"
 	KubernetesConfigDefault                  string = ""
 	DeviceInstructionTimeoutURIQueryStr      string = "timeout"
-	DeviceDefaultGolbalTimeoutInSeconds      int    = 3
+	DeviceDefaultGlobalTimeoutInSeconds      int    = 3
 	DefaultHTTPServerTimeoutInSeconds        int    = 0
 	DeviceDefaultCMDDoNotExec                string = "issue_cmd"
 	DeviceDefaultCMDStubHealth               string = "stub_health"

--- a/pkg/deviceshifu/deviceshifuhttp/configmap_snippet2.yaml
+++ b/pkg/deviceshifu/deviceshifuhttp/configmap_snippet2.yaml
@@ -5,7 +5,7 @@ data:
     driverExecution: python mock_driver.py
   instructions: |
     instructionSettings:
-      defaultTimeoutSeconds: 4
+      defaultTimeoutSeconds: -1
     instructions:
       get_reading:
       get_status:

--- a/pkg/deviceshifu/deviceshifuhttp/deviceshifuhttp_test.go
+++ b/pkg/deviceshifu/deviceshifuhttp/deviceshifuhttp_test.go
@@ -19,7 +19,18 @@ import (
 func TestMain(m *testing.M) {
 	err := GenerateConfigMapFromSnippet(MockDeviceCmStr, MockDeviceConfigFolder)
 	if err != nil {
-		klog.Errorf("error when generateConfigmapFromSnippet,err: %v", err)
+		klog.Errorf("error when generateConfigmapFromSnippet, err: %v", err)
+		os.Exit(-1)
+	}
+	m.Run()
+	err = os.RemoveAll(MockDeviceConfigPath)
+	if err != nil {
+		klog.Fatal(err)
+	}
+
+	err = GenerateConfigMapFromSnippet(MockDeviceCmStr2, MockDeviceConfigFolder)
+	if err != nil {
+		klog.Errorf("error when generateConfigmapFromSnippet2, err: %v", err)
 		os.Exit(-1)
 	}
 	m.Run()
@@ -41,6 +52,20 @@ func TestDeviceShifuEmptyNamespace(t *testing.T) {
 		klog.Errorf("%v", err)
 	} else {
 		t.Errorf("DeviceShifuHTTP Test with empty namespace failed")
+	}
+}
+
+func TestDeviceShifuNegativeInstructionTimeout(t *testing.T) {
+	deviceShifuMetadata := &deviceshifubase.DeviceShifuMetaData{
+		Name:           "TestDeviceShifuEmptyNamespace",
+		ConfigFilePath: "etc/edgedevice/config",
+		KubeConfigPath: deviceshifubase.DeviceKubeconfigDoNotLoadStr,
+		Namespace:      "TestStartNamespace",
+	}
+
+	_, err := New(deviceShifuMetadata)
+	if err != nil {
+		t.Errorf("DeviceShifuHTTP Test with default instruction timeouts failed")
 	}
 }
 

--- a/pkg/deviceshifu/deviceshifuhttp/deviceshifuhttp_test.go
+++ b/pkg/deviceshifu/deviceshifuhttp/deviceshifuhttp_test.go
@@ -55,20 +55,6 @@ func TestDeviceShifuEmptyNamespace(t *testing.T) {
 	}
 }
 
-func TestDeviceShifuNegativeInstructionTimeout(t *testing.T) {
-	deviceShifuMetadata := &deviceshifubase.DeviceShifuMetaData{
-		Name:           "TestDeviceShifuEmptyNamespace",
-		ConfigFilePath: "etc/edgedevice/config",
-		KubeConfigPath: deviceshifubase.DeviceKubeconfigDoNotLoadStr,
-		Namespace:      "TestStartNamespace",
-	}
-
-	_, err := New(deviceShifuMetadata)
-	if err != nil {
-		t.Errorf("DeviceShifuHTTP Test with default instruction timeouts failed")
-	}
-}
-
 func TestStart(t *testing.T) {
 	deviceShifuMetadata := &deviceshifubase.DeviceShifuMetaData{
 		Name:           "TestStart",

--- a/pkg/deviceshifu/deviceshifuhttp/deviceshifuhttpconfig_test.go
+++ b/pkg/deviceshifu/deviceshifuhttp/deviceshifuhttpconfig_test.go
@@ -16,6 +16,7 @@ import (
 // Str and default value
 const (
 	MockDeviceCmStr              = "configmap_snippet.yaml"
+	MockDeviceCmStr2             = "configmap_snippet2.yaml"
 	MockDeviceWritFilePermission = 0644
 	MockDeviceConfigPath         = "etc"
 )


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
This PR fixes the deviceshifuHTTP crash issue when instruction timeout is < 0

**Will this PR make the community happier**? 
Yes

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**How is this PR tested**
- [x] unit test
- [ ] e2e test
- [ ] other (please specify)

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
- added new config with negative snippet
- updates instruction timeout check
- move telemetry config validation outside
```
