### PR TITLE
[Issue #321] Use gcr.io/distroless for all images

### DIFF
--- a/examples/deviceshifu/mockdevice/agv/Dockerfile.mockdevice-agv
+++ b/examples/deviceshifu/mockdevice/agv/Dockerfile.mockdevice-agv
@@ -3,7 +3,6 @@ FROM --platform=$BUILDPLATFORM golang:1.19 as builder
 
 WORKDIR /shifu
 
-ENV GOPROXY=https://goproxy.cn,direct
 ENV GO111MODULE=on
 ENV GOPRIVATE=github.com/Edgenesis
 
@@ -24,7 +23,7 @@ RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -a \
     -o /output/mockdevice-agv \
     /shifu/deviceshifu/pkg/mockdevice/mockdevice-agv/mockdevice-agv.go
 
-FROM edgehub/distroless-static:nonroot
+FROM gcr.io/distroless/static-debian11
 WORKDIR /
 COPY --from=builder /output/mockdevice-agv mockdevice-agv
 

--- a/examples/deviceshifu/mockdevice/plate-reader/Dockerfile.mockdevice-plate-reader
+++ b/examples/deviceshifu/mockdevice/plate-reader/Dockerfile.mockdevice-plate-reader
@@ -3,7 +3,6 @@ FROM --platform=$BUILDPLATFORM golang:1.19 as builder
 
 WORKDIR /shifu
 
-ENV GOPROXY=https://goproxy.cn,direct
 ENV GO111MODULE=on
 ENV GOPRIVATE=github.com/Edgenesis
 
@@ -24,7 +23,7 @@ RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -a \
     -o /output/mockdevice-plate-reader \
     /shifu/deviceshifu/pkg/mockdevice/mockdevice-plate-reader/mockdevice-plate-reader.go
 
-FROM edgehub/distroless-static:nonroot
+FROM gcr.io/distroless/static-debian11
 WORKDIR /
 COPY --from=builder /output/mockdevice-plate-reader mockdevice-plate-reader
 

--- a/examples/deviceshifu/mockdevice/plc/Dockerfile.mockdevice-plc
+++ b/examples/deviceshifu/mockdevice/plc/Dockerfile.mockdevice-plc
@@ -3,7 +3,6 @@ FROM --platform=$BUILDPLATFORM golang:1.19 as builder
 
 WORKDIR /shifu
 
-ENV GOPROXY=https://goproxy.cn,direct
 ENV GO111MODULE=on
 ENV GOPRIVATE=github.com/Edgenesis
 
@@ -20,7 +19,7 @@ ARG TARGETARCH
 RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -a -o /output/mockdevice-plc \
     /shifu/pkg/deviceshifu/mockdevice/mockdevice-plc/mockdevice-plc.go
 
-FROM edgehub/distroless-static:nonroot
+FROM gcr.io/distroless/static-debian11
 WORKDIR /
 COPY --from=builder /output/mockdevice-plc mockdevice-plc
 COPY go.mod go.mod

--- a/examples/deviceshifu/mockdevice/robot-arm/Dockerfile.mockdevice-robot-arm
+++ b/examples/deviceshifu/mockdevice/robot-arm/Dockerfile.mockdevice-robot-arm
@@ -3,7 +3,6 @@ FROM --platform=$BUILDPLATFORM golang:1.19 as builder
 
 WORKDIR /shifu
 
-ENV GOPROXY=https://goproxy.cn,direct
 ENV GO111MODULE=on
 ENV GOPRIVATE=github.com/Edgenesis
 
@@ -24,7 +23,7 @@ RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -a \
     -o /output/mockdevice-robot-arm \
     /shifu/deviceshifu/pkg/mockdevice/mockdevice-robot-arm/mockdevice-robot-arm.go
 
-FROM edgehub/distroless-static:nonroot
+FROM gcr.io/distroless/static-debian11
 WORKDIR /
 COPY --from=builder /output/mockdevice-robot-arm mockdevice-robot-arm
 

--- a/examples/deviceshifu/mockdevice/thermometer/Dockerfile.mockdevice-thermometer
+++ b/examples/deviceshifu/mockdevice/thermometer/Dockerfile.mockdevice-thermometer
@@ -3,7 +3,6 @@ FROM --platform=$BUILDPLATFORM golang:1.19 as builder
 
 WORKDIR /shifu
 
-ENV GOPROXY=https://goproxy.cn,direct
 ENV GO111MODULE=on
 ENV GOPRIVATE=github.com/Edgenesis
 
@@ -24,7 +23,7 @@ RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -a \
     -o /output/mockdevice-thermometer \
     /shifu/deviceshifu/pkg/mockdevice/mockdevice-thermometer/mockdevice-thermometer.go
 
-FROM edgehub/distroless-static:nonroot
+FROM gcr.io/distroless/static-debian11
 WORKDIR /
 COPY --from=builder /output/mockdevice-thermometer mockdevice-thermometer
 

--- a/examples/driver_utils/simple-alpine/Dockerfile.sample
+++ b/examples/driver_utils/simple-alpine/Dockerfile.sample
@@ -2,7 +2,6 @@ FROM golang:1.19 as builder
 
 WORKDIR /
 
-ENV GOPROXY=https://goproxy.cn,direct
 ENV GO111MODULE=on
 ENV GOPRIVATE=github.com/Edgenesis
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
This PR updates all mockdevices' base image to gcr.io/distroless

**Will this PR make the community happier**? 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**How is this PR tested**
- [ ] unit test
- [x] e2e test
- [ ] other (please specify)

will be tested in E2E pipeline

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
- updates all mockevices' base image to gcr.io/distroless/static-debian11
- remove go proxies
```
