### PR TITLE
modify unit test code `strPointer .. ` using Paradigm type

### DIFF
--- a/pkg/deviceshifu/deviceshifubase/deviceshifubase_config_test.go
+++ b/pkg/deviceshifu/deviceshifubase/deviceshifubase_config_test.go
@@ -242,7 +242,7 @@ func mockHttpServer(t *testing.T) *httptest.Server {
 				Namespace: "test_namespace",
 			},
 			Status: v1alpha1.EdgeDeviceStatus{
-				EdgeDevicePhase: (*v1alpha1.EdgeDevicePhase)(unitest.StrPointer("Success")),
+				EdgeDevicePhase: (*v1alpha1.EdgeDevicePhase)(unitest.Pointer("Success")),
 			},
 		},
 	}

--- a/pkg/deviceshifu/deviceshifubase/deviceshifubase_config_test.go
+++ b/pkg/deviceshifu/deviceshifubase/deviceshifubase_config_test.go
@@ -242,7 +242,7 @@ func mockHttpServer(t *testing.T) *httptest.Server {
 				Namespace: "test_namespace",
 			},
 			Status: v1alpha1.EdgeDeviceStatus{
-				EdgeDevicePhase: (*v1alpha1.EdgeDevicePhase)(unitest.Pointer("Success")),
+				EdgeDevicePhase: (*v1alpha1.EdgeDevicePhase)(unitest.ToPointer("Success")),
 			},
 		},
 	}

--- a/pkg/deviceshifu/deviceshifubase/deviceshifubase_test.go
+++ b/pkg/deviceshifu/deviceshifubase/deviceshifubase_test.go
@@ -47,9 +47,9 @@ func TestValidateTelemetryConfig(t *testing.T) {
 				DeviceShifuConfig: &DeviceShifuConfig{
 					Telemetries: &DeviceShifuTelemetries{
 						DeviceShifuTelemetrySettings: &DeviceShifuTelemetrySettings{
-							DeviceShifuTelemetryDefaultPushToServer:          unitest.Pointer(true),
-							DeviceShifuTelemetryDefaultCollectionService:     unitest.Pointer("test_endpoint-1"),
-							DeviceShifuTelemetryUpdateIntervalInMilliseconds: unitest.Pointer(int64(-1)),
+							DeviceShifuTelemetryDefaultPushToServer:          unitest.ToPointer(true),
+							DeviceShifuTelemetryDefaultCollectionService:     unitest.ToPointer("test_endpoint-1"),
+							DeviceShifuTelemetryUpdateIntervalInMilliseconds: unitest.ToPointer(int64(-1)),
 						},
 					},
 				},
@@ -63,9 +63,9 @@ func TestValidateTelemetryConfig(t *testing.T) {
 				DeviceShifuConfig: &DeviceShifuConfig{
 					Telemetries: &DeviceShifuTelemetries{
 						DeviceShifuTelemetrySettings: &DeviceShifuTelemetrySettings{
-							DeviceShifuTelemetryDefaultPushToServer:        unitest.Pointer(true),
-							DeviceShifuTelemetryDefaultCollectionService:   unitest.Pointer("test_endpoint-1"),
-							DeviceShifuTelemetryInitialDelayInMilliseconds: unitest.Pointer(int64(-1)),
+							DeviceShifuTelemetryDefaultPushToServer:        unitest.ToPointer(true),
+							DeviceShifuTelemetryDefaultCollectionService:   unitest.ToPointer("test_endpoint-1"),
+							DeviceShifuTelemetryInitialDelayInMilliseconds: unitest.ToPointer(int64(-1)),
 						},
 					},
 				},
@@ -79,9 +79,9 @@ func TestValidateTelemetryConfig(t *testing.T) {
 				DeviceShifuConfig: &DeviceShifuConfig{
 					Telemetries: &DeviceShifuTelemetries{
 						DeviceShifuTelemetrySettings: &DeviceShifuTelemetrySettings{
-							DeviceShifuTelemetryDefaultPushToServer:      unitest.Pointer(true),
-							DeviceShifuTelemetryDefaultCollectionService: unitest.Pointer("test_endpoint-1"),
-							DeviceShifuTelemetryTimeoutInMilliseconds:    unitest.Pointer(int64(-1)),
+							DeviceShifuTelemetryDefaultPushToServer:      unitest.ToPointer(true),
+							DeviceShifuTelemetryDefaultCollectionService: unitest.ToPointer("test_endpoint-1"),
+							DeviceShifuTelemetryTimeoutInMilliseconds:    unitest.ToPointer(int64(-1)),
 						},
 					},
 				},
@@ -115,17 +115,17 @@ func TestStartTelemetryCollection(t *testing.T) {
 		DeviceShifuConfig: &DeviceShifuConfig{
 			Telemetries: &DeviceShifuTelemetries{
 				DeviceShifuTelemetrySettings: &DeviceShifuTelemetrySettings{
-					DeviceShifuTelemetryDefaultPushToServer:      unitest.Pointer(true),
-					DeviceShifuTelemetryDefaultCollectionService: unitest.Pointer("test_endpoint-1"),
+					DeviceShifuTelemetryDefaultPushToServer:      unitest.ToPointer(true),
+					DeviceShifuTelemetryDefaultCollectionService: unitest.ToPointer("test_endpoint-1"),
 				},
 				DeviceShifuTelemetries: map[string]*DeviceShifuTelemetry{
 					"device_healthy": {
 						DeviceShifuTelemetryProperties: DeviceShifuTelemetryProperties{
 							PushSettings: &DeviceShifuTelemetryPushSettings{
-								DeviceShifuTelemetryPushToServer:      unitest.Pointer(false),
-								DeviceShifuTelemetryCollectionService: unitest.Pointer("test_endpoint-1"),
+								DeviceShifuTelemetryPushToServer:      unitest.ToPointer(false),
+								DeviceShifuTelemetryCollectionService: unitest.ToPointer("test_endpoint-1"),
 							},
-							InitialDelayMs: unitest.Pointer(1),
+							InitialDelayMs: unitest.ToPointer(1),
 						},
 					},
 				},

--- a/pkg/deviceshifu/deviceshifubase/deviceshifubase_test.go
+++ b/pkg/deviceshifu/deviceshifubase/deviceshifubase_test.go
@@ -47,9 +47,9 @@ func TestValidateTelemetryConfig(t *testing.T) {
 				DeviceShifuConfig: &DeviceShifuConfig{
 					Telemetries: &DeviceShifuTelemetries{
 						DeviceShifuTelemetrySettings: &DeviceShifuTelemetrySettings{
-							DeviceShifuTelemetryDefaultPushToServer:          unitest.BoolPointer(true),
-							DeviceShifuTelemetryDefaultCollectionService:     unitest.StrPointer("test_endpoint-1"),
-							DeviceShifuTelemetryUpdateIntervalInMilliseconds: unitest.Int64Pointer(-1),
+							DeviceShifuTelemetryDefaultPushToServer:          unitest.Pointer(true),
+							DeviceShifuTelemetryDefaultCollectionService:     unitest.Pointer("test_endpoint-1"),
+							DeviceShifuTelemetryUpdateIntervalInMilliseconds: unitest.Pointer(int64(-1)),
 						},
 					},
 				},
@@ -63,9 +63,9 @@ func TestValidateTelemetryConfig(t *testing.T) {
 				DeviceShifuConfig: &DeviceShifuConfig{
 					Telemetries: &DeviceShifuTelemetries{
 						DeviceShifuTelemetrySettings: &DeviceShifuTelemetrySettings{
-							DeviceShifuTelemetryDefaultPushToServer:        unitest.BoolPointer(true),
-							DeviceShifuTelemetryDefaultCollectionService:   unitest.StrPointer("test_endpoint-1"),
-							DeviceShifuTelemetryInitialDelayInMilliseconds: unitest.Int64Pointer(-1),
+							DeviceShifuTelemetryDefaultPushToServer:        unitest.Pointer(true),
+							DeviceShifuTelemetryDefaultCollectionService:   unitest.Pointer("test_endpoint-1"),
+							DeviceShifuTelemetryInitialDelayInMilliseconds: unitest.Pointer(int64(-1)),
 						},
 					},
 				},
@@ -79,9 +79,9 @@ func TestValidateTelemetryConfig(t *testing.T) {
 				DeviceShifuConfig: &DeviceShifuConfig{
 					Telemetries: &DeviceShifuTelemetries{
 						DeviceShifuTelemetrySettings: &DeviceShifuTelemetrySettings{
-							DeviceShifuTelemetryDefaultPushToServer:      unitest.BoolPointer(true),
-							DeviceShifuTelemetryDefaultCollectionService: unitest.StrPointer("test_endpoint-1"),
-							DeviceShifuTelemetryTimeoutInMilliseconds:    unitest.Int64Pointer(-1),
+							DeviceShifuTelemetryDefaultPushToServer:      unitest.Pointer(true),
+							DeviceShifuTelemetryDefaultCollectionService: unitest.Pointer("test_endpoint-1"),
+							DeviceShifuTelemetryTimeoutInMilliseconds:    unitest.Pointer(int64(-1)),
 						},
 					},
 				},
@@ -115,17 +115,17 @@ func TestStartTelemetryCollection(t *testing.T) {
 		DeviceShifuConfig: &DeviceShifuConfig{
 			Telemetries: &DeviceShifuTelemetries{
 				DeviceShifuTelemetrySettings: &DeviceShifuTelemetrySettings{
-					DeviceShifuTelemetryDefaultPushToServer:      unitest.BoolPointer(true),
-					DeviceShifuTelemetryDefaultCollectionService: unitest.StrPointer("test_endpoint-1"),
+					DeviceShifuTelemetryDefaultPushToServer:      unitest.Pointer(true),
+					DeviceShifuTelemetryDefaultCollectionService: unitest.Pointer("test_endpoint-1"),
 				},
 				DeviceShifuTelemetries: map[string]*DeviceShifuTelemetry{
 					"device_healthy": {
 						DeviceShifuTelemetryProperties: DeviceShifuTelemetryProperties{
 							PushSettings: &DeviceShifuTelemetryPushSettings{
-								DeviceShifuTelemetryPushToServer:      unitest.BoolPointer(false),
-								DeviceShifuTelemetryCollectionService: unitest.StrPointer("test_endpoint-1"),
+								DeviceShifuTelemetryPushToServer:      unitest.Pointer(false),
+								DeviceShifuTelemetryCollectionService: unitest.Pointer("test_endpoint-1"),
 							},
-							InitialDelayMs: unitest.IntPointer(1),
+							InitialDelayMs: unitest.Pointer(1),
 						},
 					},
 				},

--- a/pkg/deviceshifu/deviceshifubase/push_telemetry_test.go
+++ b/pkg/deviceshifu/deviceshifubase/push_telemetry_test.go
@@ -78,8 +78,8 @@ func TestGetTelemetryCollectionServiceMap(t *testing.T) {
 				DeviceShifuConfig: &DeviceShifuConfig{
 					Telemetries: &DeviceShifuTelemetries{
 						DeviceShifuTelemetrySettings: &DeviceShifuTelemetrySettings{
-							DeviceShifuTelemetryDefaultPushToServer:      unitest.Pointer(false),
-							DeviceShifuTelemetryDefaultCollectionService: unitest.Pointer(""),
+							DeviceShifuTelemetryDefaultPushToServer:      unitest.ToPointer(false),
+							DeviceShifuTelemetryDefaultCollectionService: unitest.ToPointer(""),
 						},
 					},
 				},
@@ -93,8 +93,8 @@ func TestGetTelemetryCollectionServiceMap(t *testing.T) {
 				DeviceShifuConfig: &DeviceShifuConfig{
 					Telemetries: &DeviceShifuTelemetries{
 						DeviceShifuTelemetrySettings: &DeviceShifuTelemetrySettings{
-							DeviceShifuTelemetryDefaultPushToServer:      unitest.Pointer(true),
-							DeviceShifuTelemetryDefaultCollectionService: unitest.Pointer(""),
+							DeviceShifuTelemetryDefaultPushToServer:      unitest.ToPointer(true),
+							DeviceShifuTelemetryDefaultCollectionService: unitest.ToPointer(""),
 						},
 					},
 				},
@@ -114,8 +114,8 @@ func TestGetTelemetryCollectionServiceMap(t *testing.T) {
 				DeviceShifuConfig: &DeviceShifuConfig{
 					Telemetries: &DeviceShifuTelemetries{
 						DeviceShifuTelemetrySettings: &DeviceShifuTelemetrySettings{
-							DeviceShifuTelemetryDefaultPushToServer:      unitest.Pointer(true),
-							DeviceShifuTelemetryDefaultCollectionService: unitest.Pointer("test_endpoint-1"),
+							DeviceShifuTelemetryDefaultPushToServer:      unitest.ToPointer(true),
+							DeviceShifuTelemetryDefaultCollectionService: unitest.ToPointer("test_endpoint-1"),
 						},
 					},
 				},
@@ -136,15 +136,15 @@ func TestGetTelemetryCollectionServiceMap(t *testing.T) {
 				DeviceShifuConfig: &DeviceShifuConfig{
 					Telemetries: &DeviceShifuTelemetries{
 						DeviceShifuTelemetrySettings: &DeviceShifuTelemetrySettings{
-							DeviceShifuTelemetryDefaultPushToServer:      unitest.Pointer(true),
-							DeviceShifuTelemetryDefaultCollectionService: unitest.Pointer("test_endpoint-1"),
+							DeviceShifuTelemetryDefaultPushToServer:      unitest.ToPointer(true),
+							DeviceShifuTelemetryDefaultCollectionService: unitest.ToPointer("test_endpoint-1"),
 						},
 						DeviceShifuTelemetries: map[string]*DeviceShifuTelemetry{
 							"device_healthy": {
 								DeviceShifuTelemetryProperties: DeviceShifuTelemetryProperties{
 									PushSettings: &DeviceShifuTelemetryPushSettings{
-										DeviceShifuTelemetryPushToServer:      unitest.Pointer(true),
-										DeviceShifuTelemetryCollectionService: unitest.Pointer(""),
+										DeviceShifuTelemetryPushToServer:      unitest.ToPointer(true),
+										DeviceShifuTelemetryCollectionService: unitest.ToPointer(""),
 									},
 								},
 							},
@@ -168,8 +168,8 @@ func TestGetTelemetryCollectionServiceMap(t *testing.T) {
 				DeviceShifuConfig: &DeviceShifuConfig{
 					Telemetries: &DeviceShifuTelemetries{
 						DeviceShifuTelemetrySettings: &DeviceShifuTelemetrySettings{
-							DeviceShifuTelemetryDefaultPushToServer:      unitest.Pointer(true),
-							DeviceShifuTelemetryDefaultCollectionService: unitest.Pointer("test_endpoint-1"),
+							DeviceShifuTelemetryDefaultPushToServer:      unitest.ToPointer(true),
+							DeviceShifuTelemetryDefaultCollectionService: unitest.ToPointer("test_endpoint-1"),
 						},
 						DeviceShifuTelemetries: map[string]*DeviceShifuTelemetry{
 							"device_healthy": {
@@ -195,15 +195,15 @@ func TestGetTelemetryCollectionServiceMap(t *testing.T) {
 				DeviceShifuConfig: &DeviceShifuConfig{
 					Telemetries: &DeviceShifuTelemetries{
 						DeviceShifuTelemetrySettings: &DeviceShifuTelemetrySettings{
-							DeviceShifuTelemetryDefaultPushToServer:      unitest.Pointer(true),
-							DeviceShifuTelemetryDefaultCollectionService: unitest.Pointer("test_endpoint-1"),
+							DeviceShifuTelemetryDefaultPushToServer:      unitest.ToPointer(true),
+							DeviceShifuTelemetryDefaultCollectionService: unitest.ToPointer("test_endpoint-1"),
 						},
 						DeviceShifuTelemetries: map[string]*DeviceShifuTelemetry{
 							"device_healthy": {
 								DeviceShifuTelemetryProperties: DeviceShifuTelemetryProperties{
 									PushSettings: &DeviceShifuTelemetryPushSettings{
-										DeviceShifuTelemetryPushToServer:      unitest.Pointer(true),
-										DeviceShifuTelemetryCollectionService: unitest.Pointer("test-healthy-endpoint"),
+										DeviceShifuTelemetryPushToServer:      unitest.ToPointer(true),
+										DeviceShifuTelemetryCollectionService: unitest.ToPointer("test-healthy-endpoint"),
 									},
 								},
 							},
@@ -227,15 +227,15 @@ func TestGetTelemetryCollectionServiceMap(t *testing.T) {
 				DeviceShifuConfig: &DeviceShifuConfig{
 					Telemetries: &DeviceShifuTelemetries{
 						DeviceShifuTelemetrySettings: &DeviceShifuTelemetrySettings{
-							DeviceShifuTelemetryDefaultPushToServer:      unitest.Pointer(true),
-							DeviceShifuTelemetryDefaultCollectionService: unitest.Pointer("test_endpoint-1"),
+							DeviceShifuTelemetryDefaultPushToServer:      unitest.ToPointer(true),
+							DeviceShifuTelemetryDefaultCollectionService: unitest.ToPointer("test_endpoint-1"),
 						},
 						DeviceShifuTelemetries: map[string]*DeviceShifuTelemetry{
 							"device_healthy": {
 								DeviceShifuTelemetryProperties: DeviceShifuTelemetryProperties{
 									PushSettings: &DeviceShifuTelemetryPushSettings{
-										DeviceShifuTelemetryPushToServer:      unitest.Pointer(true),
-										DeviceShifuTelemetryCollectionService: unitest.Pointer("test_endpoint-1"),
+										DeviceShifuTelemetryPushToServer:      unitest.ToPointer(true),
+										DeviceShifuTelemetryCollectionService: unitest.ToPointer("test_endpoint-1"),
 									},
 								},
 							},
@@ -259,15 +259,15 @@ func TestGetTelemetryCollectionServiceMap(t *testing.T) {
 				DeviceShifuConfig: &DeviceShifuConfig{
 					Telemetries: &DeviceShifuTelemetries{
 						DeviceShifuTelemetrySettings: &DeviceShifuTelemetrySettings{
-							DeviceShifuTelemetryDefaultPushToServer:      unitest.Pointer(true),
-							DeviceShifuTelemetryDefaultCollectionService: unitest.Pointer("test_endpoint-1"),
+							DeviceShifuTelemetryDefaultPushToServer:      unitest.ToPointer(true),
+							DeviceShifuTelemetryDefaultCollectionService: unitest.ToPointer("test_endpoint-1"),
 						},
 						DeviceShifuTelemetries: map[string]*DeviceShifuTelemetry{
 							"device_healthy": {
 								DeviceShifuTelemetryProperties: DeviceShifuTelemetryProperties{
 									PushSettings: &DeviceShifuTelemetryPushSettings{
-										DeviceShifuTelemetryPushToServer:      unitest.Pointer(false),
-										DeviceShifuTelemetryCollectionService: unitest.Pointer("test_endpoint-1"),
+										DeviceShifuTelemetryPushToServer:      unitest.ToPointer(false),
+										DeviceShifuTelemetryCollectionService: unitest.ToPointer("test_endpoint-1"),
 									},
 								},
 							},

--- a/pkg/deviceshifu/deviceshifubase/push_telemetry_test.go
+++ b/pkg/deviceshifu/deviceshifubase/push_telemetry_test.go
@@ -78,8 +78,8 @@ func TestGetTelemetryCollectionServiceMap(t *testing.T) {
 				DeviceShifuConfig: &DeviceShifuConfig{
 					Telemetries: &DeviceShifuTelemetries{
 						DeviceShifuTelemetrySettings: &DeviceShifuTelemetrySettings{
-							DeviceShifuTelemetryDefaultPushToServer:      unitest.BoolPointer(false),
-							DeviceShifuTelemetryDefaultCollectionService: unitest.StrPointer(""),
+							DeviceShifuTelemetryDefaultPushToServer:      unitest.Pointer(false),
+							DeviceShifuTelemetryDefaultCollectionService: unitest.Pointer(""),
 						},
 					},
 				},
@@ -93,8 +93,8 @@ func TestGetTelemetryCollectionServiceMap(t *testing.T) {
 				DeviceShifuConfig: &DeviceShifuConfig{
 					Telemetries: &DeviceShifuTelemetries{
 						DeviceShifuTelemetrySettings: &DeviceShifuTelemetrySettings{
-							DeviceShifuTelemetryDefaultPushToServer:      unitest.BoolPointer(true),
-							DeviceShifuTelemetryDefaultCollectionService: unitest.StrPointer(""),
+							DeviceShifuTelemetryDefaultPushToServer:      unitest.Pointer(true),
+							DeviceShifuTelemetryDefaultCollectionService: unitest.Pointer(""),
 						},
 					},
 				},
@@ -114,8 +114,8 @@ func TestGetTelemetryCollectionServiceMap(t *testing.T) {
 				DeviceShifuConfig: &DeviceShifuConfig{
 					Telemetries: &DeviceShifuTelemetries{
 						DeviceShifuTelemetrySettings: &DeviceShifuTelemetrySettings{
-							DeviceShifuTelemetryDefaultPushToServer:      unitest.BoolPointer(true),
-							DeviceShifuTelemetryDefaultCollectionService: unitest.StrPointer("test_endpoint-1"),
+							DeviceShifuTelemetryDefaultPushToServer:      unitest.Pointer(true),
+							DeviceShifuTelemetryDefaultCollectionService: unitest.Pointer("test_endpoint-1"),
 						},
 					},
 				},
@@ -136,15 +136,15 @@ func TestGetTelemetryCollectionServiceMap(t *testing.T) {
 				DeviceShifuConfig: &DeviceShifuConfig{
 					Telemetries: &DeviceShifuTelemetries{
 						DeviceShifuTelemetrySettings: &DeviceShifuTelemetrySettings{
-							DeviceShifuTelemetryDefaultPushToServer:      unitest.BoolPointer(true),
-							DeviceShifuTelemetryDefaultCollectionService: unitest.StrPointer("test_endpoint-1"),
+							DeviceShifuTelemetryDefaultPushToServer:      unitest.Pointer(true),
+							DeviceShifuTelemetryDefaultCollectionService: unitest.Pointer("test_endpoint-1"),
 						},
 						DeviceShifuTelemetries: map[string]*DeviceShifuTelemetry{
 							"device_healthy": {
 								DeviceShifuTelemetryProperties: DeviceShifuTelemetryProperties{
 									PushSettings: &DeviceShifuTelemetryPushSettings{
-										DeviceShifuTelemetryPushToServer:      unitest.BoolPointer(true),
-										DeviceShifuTelemetryCollectionService: unitest.StrPointer(""),
+										DeviceShifuTelemetryPushToServer:      unitest.Pointer(true),
+										DeviceShifuTelemetryCollectionService: unitest.Pointer(""),
 									},
 								},
 							},
@@ -168,8 +168,8 @@ func TestGetTelemetryCollectionServiceMap(t *testing.T) {
 				DeviceShifuConfig: &DeviceShifuConfig{
 					Telemetries: &DeviceShifuTelemetries{
 						DeviceShifuTelemetrySettings: &DeviceShifuTelemetrySettings{
-							DeviceShifuTelemetryDefaultPushToServer:      unitest.BoolPointer(true),
-							DeviceShifuTelemetryDefaultCollectionService: unitest.StrPointer("test_endpoint-1"),
+							DeviceShifuTelemetryDefaultPushToServer:      unitest.Pointer(true),
+							DeviceShifuTelemetryDefaultCollectionService: unitest.Pointer("test_endpoint-1"),
 						},
 						DeviceShifuTelemetries: map[string]*DeviceShifuTelemetry{
 							"device_healthy": {
@@ -195,15 +195,15 @@ func TestGetTelemetryCollectionServiceMap(t *testing.T) {
 				DeviceShifuConfig: &DeviceShifuConfig{
 					Telemetries: &DeviceShifuTelemetries{
 						DeviceShifuTelemetrySettings: &DeviceShifuTelemetrySettings{
-							DeviceShifuTelemetryDefaultPushToServer:      unitest.BoolPointer(true),
-							DeviceShifuTelemetryDefaultCollectionService: unitest.StrPointer("test_endpoint-1"),
+							DeviceShifuTelemetryDefaultPushToServer:      unitest.Pointer(true),
+							DeviceShifuTelemetryDefaultCollectionService: unitest.Pointer("test_endpoint-1"),
 						},
 						DeviceShifuTelemetries: map[string]*DeviceShifuTelemetry{
 							"device_healthy": {
 								DeviceShifuTelemetryProperties: DeviceShifuTelemetryProperties{
 									PushSettings: &DeviceShifuTelemetryPushSettings{
-										DeviceShifuTelemetryPushToServer:      unitest.BoolPointer(true),
-										DeviceShifuTelemetryCollectionService: unitest.StrPointer("test-healthy-endpoint"),
+										DeviceShifuTelemetryPushToServer:      unitest.Pointer(true),
+										DeviceShifuTelemetryCollectionService: unitest.Pointer("test-healthy-endpoint"),
 									},
 								},
 							},
@@ -227,15 +227,15 @@ func TestGetTelemetryCollectionServiceMap(t *testing.T) {
 				DeviceShifuConfig: &DeviceShifuConfig{
 					Telemetries: &DeviceShifuTelemetries{
 						DeviceShifuTelemetrySettings: &DeviceShifuTelemetrySettings{
-							DeviceShifuTelemetryDefaultPushToServer:      unitest.BoolPointer(true),
-							DeviceShifuTelemetryDefaultCollectionService: unitest.StrPointer("test_endpoint-1"),
+							DeviceShifuTelemetryDefaultPushToServer:      unitest.Pointer(true),
+							DeviceShifuTelemetryDefaultCollectionService: unitest.Pointer("test_endpoint-1"),
 						},
 						DeviceShifuTelemetries: map[string]*DeviceShifuTelemetry{
 							"device_healthy": {
 								DeviceShifuTelemetryProperties: DeviceShifuTelemetryProperties{
 									PushSettings: &DeviceShifuTelemetryPushSettings{
-										DeviceShifuTelemetryPushToServer:      unitest.BoolPointer(true),
-										DeviceShifuTelemetryCollectionService: unitest.StrPointer("test_endpoint-1"),
+										DeviceShifuTelemetryPushToServer:      unitest.Pointer(true),
+										DeviceShifuTelemetryCollectionService: unitest.Pointer("test_endpoint-1"),
 									},
 								},
 							},
@@ -259,15 +259,15 @@ func TestGetTelemetryCollectionServiceMap(t *testing.T) {
 				DeviceShifuConfig: &DeviceShifuConfig{
 					Telemetries: &DeviceShifuTelemetries{
 						DeviceShifuTelemetrySettings: &DeviceShifuTelemetrySettings{
-							DeviceShifuTelemetryDefaultPushToServer:      unitest.BoolPointer(true),
-							DeviceShifuTelemetryDefaultCollectionService: unitest.StrPointer("test_endpoint-1"),
+							DeviceShifuTelemetryDefaultPushToServer:      unitest.Pointer(true),
+							DeviceShifuTelemetryDefaultCollectionService: unitest.Pointer("test_endpoint-1"),
 						},
 						DeviceShifuTelemetries: map[string]*DeviceShifuTelemetry{
 							"device_healthy": {
 								DeviceShifuTelemetryProperties: DeviceShifuTelemetryProperties{
 									PushSettings: &DeviceShifuTelemetryPushSettings{
-										DeviceShifuTelemetryPushToServer:      unitest.BoolPointer(false),
-										DeviceShifuTelemetryCollectionService: unitest.StrPointer("test_endpoint-1"),
+										DeviceShifuTelemetryPushToServer:      unitest.Pointer(false),
+										DeviceShifuTelemetryCollectionService: unitest.Pointer("test_endpoint-1"),
 									},
 								},
 							},

--- a/pkg/deviceshifu/deviceshifuhttp/deviceshifuhttp_test.go
+++ b/pkg/deviceshifu/deviceshifuhttp/deviceshifuhttp_test.go
@@ -376,25 +376,25 @@ func TestCollectHTTPTelemtries(t *testing.T) {
 				},
 				Spec: v1alpha1.EdgeDeviceSpec{
 					Address:  &addr,
-					Protocol: (*v1alpha1.Protocol)(unitest.Pointer(string(v1alpha1.ProtocolHTTP))),
+					Protocol: (*v1alpha1.Protocol)(unitest.ToPointer(string(v1alpha1.ProtocolHTTP))),
 				},
 			},
 			DeviceShifuConfig: &deviceshifubase.DeviceShifuConfig{
 				Telemetries: &deviceshifubase.DeviceShifuTelemetries{
 					DeviceShifuTelemetrySettings: &deviceshifubase.DeviceShifuTelemetrySettings{
-						DeviceShifuTelemetryTimeoutInMilliseconds:    unitest.Pointer(int64(10)),
-						DeviceShifuTelemetryDefaultPushToServer:      unitest.Pointer(true),
-						DeviceShifuTelemetryDefaultCollectionService: unitest.Pointer("test_endpoint-1"),
+						DeviceShifuTelemetryTimeoutInMilliseconds:    unitest.ToPointer(int64(10)),
+						DeviceShifuTelemetryDefaultPushToServer:      unitest.ToPointer(true),
+						DeviceShifuTelemetryDefaultCollectionService: unitest.ToPointer("test_endpoint-1"),
 					},
 					DeviceShifuTelemetries: map[string]*deviceshifubase.DeviceShifuTelemetry{
 						"device_healthy": {
 							DeviceShifuTelemetryProperties: deviceshifubase.DeviceShifuTelemetryProperties{
-								DeviceInstructionName: unitest.Pointer("telemetry_health"),
+								DeviceInstructionName: unitest.ToPointer("telemetry_health"),
 								PushSettings: &deviceshifubase.DeviceShifuTelemetryPushSettings{
-									DeviceShifuTelemetryPushToServer:      unitest.Pointer(false),
-									DeviceShifuTelemetryCollectionService: unitest.Pointer("test_endpoint-1"),
+									DeviceShifuTelemetryPushToServer:      unitest.ToPointer(false),
+									DeviceShifuTelemetryCollectionService: unitest.ToPointer("test_endpoint-1"),
 								},
-								InitialDelayMs: unitest.Pointer(1),
+								InitialDelayMs: unitest.ToPointer(1),
 							},
 						},
 					},

--- a/pkg/deviceshifu/deviceshifuhttp/deviceshifuhttp_test.go
+++ b/pkg/deviceshifu/deviceshifuhttp/deviceshifuhttp_test.go
@@ -376,25 +376,25 @@ func TestCollectHTTPTelemtries(t *testing.T) {
 				},
 				Spec: v1alpha1.EdgeDeviceSpec{
 					Address:  &addr,
-					Protocol: (*v1alpha1.Protocol)(unitest.StrPointer(string(v1alpha1.ProtocolHTTP))),
+					Protocol: (*v1alpha1.Protocol)(unitest.Pointer(string(v1alpha1.ProtocolHTTP))),
 				},
 			},
 			DeviceShifuConfig: &deviceshifubase.DeviceShifuConfig{
 				Telemetries: &deviceshifubase.DeviceShifuTelemetries{
 					DeviceShifuTelemetrySettings: &deviceshifubase.DeviceShifuTelemetrySettings{
-						DeviceShifuTelemetryTimeoutInMilliseconds:    unitest.Int64Pointer(10),
-						DeviceShifuTelemetryDefaultPushToServer:      unitest.BoolPointer(true),
-						DeviceShifuTelemetryDefaultCollectionService: unitest.StrPointer("test_endpoint-1"),
+						DeviceShifuTelemetryTimeoutInMilliseconds:    unitest.Pointer(int64(10)),
+						DeviceShifuTelemetryDefaultPushToServer:      unitest.Pointer(true),
+						DeviceShifuTelemetryDefaultCollectionService: unitest.Pointer("test_endpoint-1"),
 					},
 					DeviceShifuTelemetries: map[string]*deviceshifubase.DeviceShifuTelemetry{
 						"device_healthy": {
 							DeviceShifuTelemetryProperties: deviceshifubase.DeviceShifuTelemetryProperties{
-								DeviceInstructionName: unitest.StrPointer("telemetry_health"),
+								DeviceInstructionName: unitest.Pointer("telemetry_health"),
 								PushSettings: &deviceshifubase.DeviceShifuTelemetryPushSettings{
-									DeviceShifuTelemetryPushToServer:      unitest.BoolPointer(false),
-									DeviceShifuTelemetryCollectionService: unitest.StrPointer("test_endpoint-1"),
+									DeviceShifuTelemetryPushToServer:      unitest.Pointer(false),
+									DeviceShifuTelemetryCollectionService: unitest.Pointer("test_endpoint-1"),
 								},
-								InitialDelayMs: unitest.IntPointer(1),
+								InitialDelayMs: unitest.Pointer(1),
 							},
 						},
 					},

--- a/pkg/deviceshifu/deviceshifusocket/deviceshifusocket_test.go
+++ b/pkg/deviceshifu/deviceshifusocket/deviceshifusocket_test.go
@@ -379,10 +379,10 @@ func mockHttpServer(t *testing.T) *httptest.Server {
 		},
 		Spec: v1alpha1.EdgeDeviceSpec{
 			Protocol: &socketProtocol,
-			Address:  unitest.StrPointer(UnitTestAddress),
+			Address:  unitest.Pointer(UnitTestAddress),
 			ProtocolSettings: &v1alpha1.ProtocolSettings{
 				SocketSetting: &v1alpha1.SocketSetting{
-					NetworkType: unitest.StrPointer("tcp"),
+					NetworkType: unitest.Pointer("tcp"),
 				},
 			},
 		},

--- a/pkg/deviceshifu/deviceshifusocket/deviceshifusocket_test.go
+++ b/pkg/deviceshifu/deviceshifusocket/deviceshifusocket_test.go
@@ -379,10 +379,10 @@ func mockHttpServer(t *testing.T) *httptest.Server {
 		},
 		Spec: v1alpha1.EdgeDeviceSpec{
 			Protocol: &socketProtocol,
-			Address:  unitest.Pointer(UnitTestAddress),
+			Address:  unitest.ToPointer(UnitTestAddress),
 			ProtocolSettings: &v1alpha1.ProtocolSettings{
 				SocketSetting: &v1alpha1.SocketSetting{
-					NetworkType: unitest.Pointer("tcp"),
+					NetworkType: unitest.ToPointer("tcp"),
 				},
 			},
 		},

--- a/pkg/deviceshifu/unitest/convert2pointer.go
+++ b/pkg/deviceshifu/unitest/convert2pointer.go
@@ -4,18 +4,6 @@ package unitest
 // DO NOT USE IN NONE UNIT TESTING CODE
 // if there are common use case, let's move it to an much common package or even another code repo
 
-func BoolPointer(b bool) *bool {
-	return &b
-}
-
-func StrPointer(s string) *string {
-	return &s
-}
-
-func IntPointer(i int) *int {
-	return &i
-}
-
-func Int64Pointer(i int64) *int64 {
+func Pointer[T any](i T) *T {
 	return &i
 }

--- a/pkg/deviceshifu/unitest/convert2pointer.go
+++ b/pkg/deviceshifu/unitest/convert2pointer.go
@@ -4,6 +4,6 @@ package unitest
 // DO NOT USE IN NONE UNIT TESTING CODE
 // if there are common use case, let's move it to an much common package or even another code repo
 
-func Pointer[T any](i T) *T {
-	return &i
+func ToPointer[T any](v T) *T {
+	return &v
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
modify unit test code `strPointer .. ` using Paradigm type
**Will this PR make the community happier**? 
yes
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**How is this PR tested**
- [ ] unit test
- [ ] e2e test
- [x] other (please specify)

**Special notes for your reviewer**:
merge `BoolPointer`  、`StrPointer` 、 `IntPointer` 、 `Int64Pointer` to `Pointer` using `Paradigm type`
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
