### PR TITLE
Fix telemetry nil pointer

### DIFF
--- a/pkg/deviceshifu/deviceshifubase/pushtelemetry.go
+++ b/pkg/deviceshifu/deviceshifubase/pushtelemetry.go
@@ -105,7 +105,12 @@ func getTelemetryCollectionServiceMap(ds *DeviceShifuBase) (map[string]v1alpha1.
 		Protocol: &defaultTelemetryProtocol,
 		Address:  &defaultTelemetryServiceAddress,
 	}
+
 	telemetries := ds.DeviceShifuConfig.Telemetries
+	if telemetries == nil {
+		return res, nil
+	}
+
 	if telemetries.DeviceShifuTelemetrySettings == nil {
 		telemetries.DeviceShifuTelemetrySettings = &DeviceShifuTelemetrySettings{}
 	}
@@ -135,38 +140,44 @@ func getTelemetryCollectionServiceMap(ds *DeviceShifuBase) (map[string]v1alpha1.
 		serviceAddressCache[defaultTelemetryCollectionService] = telemetryService.Spec
 	}
 
-	for telemetryName, telemetries := range telemetries.DeviceShifuTelemetries {
-		pushSettings := telemetries.DeviceShifuTelemetryProperties.PushSettings
+	for telemetryName, telemetry := range telemetries.DeviceShifuTelemetries {
+		if telemetry == nil {
+			continue
+		}
 
-		if pushSettings != nil {
-			if pushSettings.DeviceShifuTelemetryPushToServer != nil {
-				if !*pushSettings.DeviceShifuTelemetryPushToServer {
-					continue
-				}
-			}
+		pushSettings := telemetry.DeviceShifuTelemetryProperties.PushSettings
+		if pushSettings == nil {
+			res[telemetryName] = *defaultTelemetryServiceSpec
+			continue
+		}
 
-			if pushSettings.DeviceShifuTelemetryCollectionService != nil &&
-				len(*pushSettings.DeviceShifuTelemetryCollectionService) != 0 {
-				if telemetryServiceAddress, exist := serviceAddressCache[*pushSettings.DeviceShifuTelemetryCollectionService]; exist {
-					res[telemetryName] = telemetryServiceAddress
-					continue
-				}
-
-				var telemetryService v1alpha1.TelemetryService
-				if err := ds.RestClient.Get().
-					Namespace(ds.EdgeDevice.Namespace).
-					Resource(TelemetryCollectionServiceResourceStr).
-					Name(*pushSettings.DeviceShifuTelemetryCollectionService).
-					Do(context.TODO()).
-					Into(&telemetryService); err != nil {
-					klog.Errorf("unable to get telemetry service %v, error: %v", *pushSettings.DeviceShifuTelemetryCollectionService, err)
-					continue
-				}
-
-				serviceAddressCache[*pushSettings.DeviceShifuTelemetryCollectionService] = telemetryService.Spec
-				res[telemetryName] = telemetryService.Spec
+		if pushSettings.DeviceShifuTelemetryPushToServer != nil {
+			if !*pushSettings.DeviceShifuTelemetryPushToServer {
 				continue
 			}
+		}
+
+		if pushSettings.DeviceShifuTelemetryCollectionService != nil &&
+			len(*pushSettings.DeviceShifuTelemetryCollectionService) != 0 {
+			if telemetryServiceAddress, exist := serviceAddressCache[*pushSettings.DeviceShifuTelemetryCollectionService]; exist {
+				res[telemetryName] = telemetryServiceAddress
+				continue
+			}
+
+			var telemetryService v1alpha1.TelemetryService
+			if err := ds.RestClient.Get().
+				Namespace(ds.EdgeDevice.Namespace).
+				Resource(TelemetryCollectionServiceResourceStr).
+				Name(*pushSettings.DeviceShifuTelemetryCollectionService).
+				Do(context.TODO()).
+				Into(&telemetryService); err != nil {
+				klog.Errorf("unable to get telemetry service %v, error: %v", *pushSettings.DeviceShifuTelemetryCollectionService, err)
+				continue
+			}
+
+			serviceAddressCache[*pushSettings.DeviceShifuTelemetryCollectionService] = telemetryService.Spec
+			res[telemetryName] = telemetryService.Spec
+			continue
 		}
 
 		res[telemetryName] = *defaultTelemetryServiceSpec

--- a/pkg/deviceshifu/deviceshifubase/pushtelemetry_test.go
+++ b/pkg/deviceshifu/deviceshifubase/pushtelemetry_test.go
@@ -105,8 +105,8 @@ func TestGetTelemetryCollectionServiceMap(t *testing.T) {
 			expErrStr:   "you need to configure defaultTelemetryCollectionService if setting defaultPushToServer to true",
 		},
 		{
-			"case 4 has default with true and valid endpoint",
-			&DeviceShifuBase{
+			Name: "case 4 has default with true and valid endpoint",
+			inputDevice: &DeviceShifuBase{
 				Name: "test",
 				EdgeDevice: &v1alpha1.EdgeDevice{
 					ObjectMeta: metav1.ObjectMeta{
@@ -123,12 +123,12 @@ func TestGetTelemetryCollectionServiceMap(t *testing.T) {
 				},
 				RestClient: mockRestClientFor("{\"spec\": {\"address\": \"http://192.168.15.48:12345/endpoint1\",\"type\": \"HTTP\"}}", t),
 			},
-			map[string]v1alpha1.TelemetryServiceSpec(map[string]v1alpha1.TelemetryServiceSpec{}),
-			"",
+			expectedMap: map[string]v1alpha1.TelemetryServiceSpec(map[string]v1alpha1.TelemetryServiceSpec{}),
+			expErrStr:   "",
 		},
 		{
-			"case 5 has default with true and valid endpoint, has telemetry with empty push setting",
-			&DeviceShifuBase{
+			Name: "case 5 has default with true and valid endpoint, has telemetry with empty push setting",
+			inputDevice: &DeviceShifuBase{
 				Name: "test",
 				EdgeDevice: &v1alpha1.EdgeDevice{
 					ObjectMeta: metav1.ObjectMeta{
@@ -155,17 +155,17 @@ func TestGetTelemetryCollectionServiceMap(t *testing.T) {
 				},
 				RestClient: mockRestClientFor("{\"spec\": {\"address\": \"http://192.168.15.48:12345/test_endpoint-1\",\"type\": \"HTTP\"}}", t),
 			},
-			map[string]v1alpha1.TelemetryServiceSpec(map[string]v1alpha1.TelemetryServiceSpec{
+			expectedMap: map[string]v1alpha1.TelemetryServiceSpec(map[string]v1alpha1.TelemetryServiceSpec{
 				"device_healthy": {
 					Protocol: unitest.ToPointer(v1alpha1.ProtocolHTTP),
 					Address:  unitest.ToPointer(""),
 				},
 			}),
-			"",
+			expErrStr: "",
 		},
 		{
-			"case 6 has default with true and valid endpoint, has telemetry with no push setting",
-			&DeviceShifuBase{
+			Name: "case 6 has default with true and valid endpoint, has telemetry with no push setting",
+			inputDevice: &DeviceShifuBase{
 				Name: "test",
 				EdgeDevice: &v1alpha1.EdgeDevice{
 					ObjectMeta: metav1.ObjectMeta{
@@ -187,17 +187,17 @@ func TestGetTelemetryCollectionServiceMap(t *testing.T) {
 				},
 				RestClient: mockRestClientFor("{\"spec\": {\"address\": \"http://192.168.15.48:12345/test_endpoint-1\",\"type\": \"HTTP\"}}", t),
 			},
-			map[string]v1alpha1.TelemetryServiceSpec(map[string]v1alpha1.TelemetryServiceSpec{
+			expectedMap: map[string]v1alpha1.TelemetryServiceSpec(map[string]v1alpha1.TelemetryServiceSpec{
 				"device_healthy": {
 					Protocol: unitest.ToPointer(v1alpha1.ProtocolHTTP),
 					Address:  unitest.ToPointer(""),
 				},
 			}),
-			"",
+			expErrStr: "",
 		},
 		{
-			"case 7 has default with true and valid endpoint, has telemetry with valid push setting",
-			&DeviceShifuBase{
+			Name: "case 7 has default with true and valid endpoint, has telemetry with valid push setting",
+			inputDevice: &DeviceShifuBase{
 				Name: "test",
 				EdgeDevice: &v1alpha1.EdgeDevice{
 					ObjectMeta: metav1.ObjectMeta{
@@ -224,16 +224,16 @@ func TestGetTelemetryCollectionServiceMap(t *testing.T) {
 				},
 				RestClient: mockRestClientFor("{\"spec\": {\"address\": \"http://192.168.15.48:12345/test-healthy-endpoint\",\"type\": \"HTTP\"}}", t),
 			},
-			map[string]v1alpha1.TelemetryServiceSpec(map[string]v1alpha1.TelemetryServiceSpec{
+			expectedMap: map[string]v1alpha1.TelemetryServiceSpec(map[string]v1alpha1.TelemetryServiceSpec{
 				"device_healthy": {
 					Address: unitest.ToPointer("http://192.168.15.48:12345/test-healthy-endpoint"),
 				},
 			}),
-			"",
+			expErrStr: "",
 		},
 		{
-			"case 8 has default with true and valid endpoint, has telemetry with same endpoint",
-			&DeviceShifuBase{
+			Name: "case 8 has default with true and valid endpoint, has telemetry with same endpoint",
+			inputDevice: &DeviceShifuBase{
 				Name: "test",
 				EdgeDevice: &v1alpha1.EdgeDevice{
 					ObjectMeta: metav1.ObjectMeta{
@@ -260,16 +260,16 @@ func TestGetTelemetryCollectionServiceMap(t *testing.T) {
 				},
 				RestClient: mockRestClientFor("{\"spec\": {\"address\": \"http://192.168.15.48:12345/test_endpoint-1\",\"type\": \"HTTP\"}}", t),
 			},
-			map[string]v1alpha1.TelemetryServiceSpec(map[string]v1alpha1.TelemetryServiceSpec{
+			expectedMap: map[string]v1alpha1.TelemetryServiceSpec(map[string]v1alpha1.TelemetryServiceSpec{
 				"device_healthy": {
 					Address: unitest.ToPointer("http://192.168.15.48:12345/test_endpoint-1"),
 				},
 			}),
-			"",
+			expErrStr: "",
 		},
 		{
-			"case 9 has default with true and valid endpoint, has telemetry with push false setting",
-			&DeviceShifuBase{
+			Name: "case 9 has default with true and valid endpoint, has telemetry with push false setting",
+			inputDevice: &DeviceShifuBase{
 				Name: "test",
 				EdgeDevice: &v1alpha1.EdgeDevice{
 					ObjectMeta: metav1.ObjectMeta{
@@ -296,16 +296,16 @@ func TestGetTelemetryCollectionServiceMap(t *testing.T) {
 				},
 				RestClient: mockRestClientFor("{\"spec\": {\"address\": \"http://192.168.15.48:12345/test_endpoint-1\",\"type\": \"HTTP\"}}", t),
 			},
-			map[string]v1alpha1.TelemetryServiceSpec(map[string]v1alpha1.TelemetryServiceSpec{}),
-			"",
+			expectedMap: map[string]v1alpha1.TelemetryServiceSpec(map[string]v1alpha1.TelemetryServiceSpec{}),
+			expErrStr:   "",
 		},
 		{
-			"case 10 no telemetry",
-			&DeviceShifuBase{
+			Name: "case 10 no telemetry",
+			inputDevice: &DeviceShifuBase{
 				DeviceShifuConfig: &DeviceShifuConfig{},
 			},
-			map[string]v1alpha1.TelemetryServiceSpec(map[string]v1alpha1.TelemetryServiceSpec{}),
-			"",
+			expectedMap: map[string]v1alpha1.TelemetryServiceSpec(map[string]v1alpha1.TelemetryServiceSpec{}),
+			expErrStr:   "",
 		},
 	}
 

--- a/pkg/deviceshifu/deviceshifubase/pushtelemetry_test.go
+++ b/pkg/deviceshifu/deviceshifubase/pushtelemetry_test.go
@@ -57,6 +57,7 @@ func TestGetTelemetryCollectionServiceMap(t *testing.T) {
 	// case 7 has default with true and valid endpoint, has telemetry with valid push setting
 	// case 8 has default with true and valid endpoint, has telemetry with same endpoint
 	// case 9 has default with true and valid endpoint, has telemetry with push false setting
+	// case 10 has default without telemetry.
 	testCases := []struct {
 		Name        string
 		inputDevice *DeviceShifuBase
@@ -64,18 +65,18 @@ func TestGetTelemetryCollectionServiceMap(t *testing.T) {
 		expErrStr   string
 	}{
 		{
-			"case 1 no setting",
-			&DeviceShifuBase{
+			Name: "case 1 no setting",
+			inputDevice: &DeviceShifuBase{
 				DeviceShifuConfig: &DeviceShifuConfig{
 					Telemetries: &DeviceShifuTelemetries{},
 				},
 			},
-			map[string]v1alpha1.TelemetryServiceSpec(map[string]v1alpha1.TelemetryServiceSpec{}),
-			"",
+			expectedMap: map[string]v1alpha1.TelemetryServiceSpec(map[string]v1alpha1.TelemetryServiceSpec{}),
+			expErrStr:   "",
 		},
 		{
-			"case 2 has default with false",
-			&DeviceShifuBase{
+			Name: "case 2 has default with false",
+			inputDevice: &DeviceShifuBase{
 				DeviceShifuConfig: &DeviceShifuConfig{
 					Telemetries: &DeviceShifuTelemetries{
 						DeviceShifuTelemetrySettings: &DeviceShifuTelemetrySettings{
@@ -85,12 +86,12 @@ func TestGetTelemetryCollectionServiceMap(t *testing.T) {
 					},
 				},
 			},
-			map[string]v1alpha1.TelemetryServiceSpec(map[string]v1alpha1.TelemetryServiceSpec{}),
-			"",
+			expectedMap: map[string]v1alpha1.TelemetryServiceSpec(map[string]v1alpha1.TelemetryServiceSpec{}),
+			expErrStr:   "",
 		},
 		{
-			"case 3 has default with true and empty endpoint",
-			&DeviceShifuBase{
+			Name: "case 3 has default with true and empty endpoint",
+			inputDevice: &DeviceShifuBase{
 				DeviceShifuConfig: &DeviceShifuConfig{
 					Telemetries: &DeviceShifuTelemetries{
 						DeviceShifuTelemetrySettings: &DeviceShifuTelemetrySettings{
@@ -100,8 +101,8 @@ func TestGetTelemetryCollectionServiceMap(t *testing.T) {
 					},
 				},
 			},
-			nil,
-			"you need to configure defaultTelemetryCollectionService if setting defaultPushToServer to true",
+			expectedMap: nil,
+			expErrStr:   "you need to configure defaultTelemetryCollectionService if setting defaultPushToServer to true",
 		},
 		{
 			"case 4 has default with true and valid endpoint",
@@ -294,6 +295,14 @@ func TestGetTelemetryCollectionServiceMap(t *testing.T) {
 					},
 				},
 				RestClient: mockRestClientFor("{\"spec\": {\"address\": \"http://192.168.15.48:12345/test_endpoint-1\",\"type\": \"HTTP\"}}", t),
+			},
+			map[string]v1alpha1.TelemetryServiceSpec(map[string]v1alpha1.TelemetryServiceSpec{}),
+			"",
+		},
+		{
+			"case 10 no telemetry",
+			&DeviceShifuBase{
+				DeviceShifuConfig: &DeviceShifuConfig{},
 			},
 			map[string]v1alpha1.TelemetryServiceSpec(map[string]v1alpha1.TelemetryServiceSpec{}),
 			"",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
This PR fixes the segmentation fault bug with telemetry is nil.
Below is a screenshot when the bug happens:

<img width="996" alt="image" src="https://user-images.githubusercontent.com/6934678/199245847-be46d9ba-1bc1-4f51-bfbc-cfe48147c9dc.png">


**Will this PR make the community happier**? 
Yes. BUG FIXES!

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**How is this PR tested**
- [x] unit test
- [ ] e2e test
- [ ] other (please specify)

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
