### PR TITLE
<Enhance> use multistage to build socket mock device

### DIFF
--- a/examples/deviceshifu/mockdevice/socket/Dockerfile.mockdevice-socket
+++ b/examples/deviceshifu/mockdevice/socket/Dockerfile.mockdevice-socket
@@ -1,11 +1,19 @@
-FROM golang:1.19.2
+FROM --platform=$BUILDPLATFORM golang:1.19.2 as builder
+WORKDIR /shifu
 
-WORKDIR /worker
-
+ENV GO111MODULE=on
 COPY examples/socketDeviceShifu/server/server.go server.go
 
-RUN go build -o /output/server server.go
+# Build the Go app
+ARG TARGETOS
+ARG TARGETARCH
 
-EXPOSE 11122:11122/tcp
+RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -a \
+    -o /output/server server.go
 
-ENTRYPOINT [ "/output/server" ]
+FROM gcr.io/distroless/static-debian11
+WORKDIR /
+COPY --from=builder /output/server server
+
+USER 65532:65532
+ENTRYPOINT [ "/server" ]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
This PR updates socket mockdevice's Dockerfile to utilize multi stage build to reduce its size
**Will this PR make the community happier**? 
Yes
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**How is this PR tested**
- [ ] unit test
- [x] e2e test
- [ ] other (please specify)

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
- use multistage build for socket mock device
```
