### PR TITLE
test: use `T.Setenv` to set env vars in tests

### DIFF
--- a/pkg/deviceshifu/deviceshifubase/deviceshifubase_test.go
+++ b/pkg/deviceshifu/deviceshifubase/deviceshifubase_test.go
@@ -180,19 +180,17 @@ func TestStartTelemetryCollection(t *testing.T) {
 }
 
 func TestNew(t *testing.T) {
-	os.Setenv("KUBERNETES_SERVICE_HOST", "localhost")
-	os.Setenv("KUBERNETES_SERVICE_PORT", "1080")
 	testCases := []struct {
 		Name      string
 		metaData  *DeviceShifuMetaData
 		expErrStr string
-		initEnv   func()
+		initEnv   func(t *testing.T)
 	}{
 		{
 			"case 1 have empty name can not new device base",
 			&DeviceShifuMetaData{},
 			"DeviceShifu's name can't be empty",
-			func() {},
+			func(t *testing.T) {},
 		},
 		{
 			"case 2 have empty configpath meta new device base",
@@ -200,7 +198,7 @@ func TestNew(t *testing.T) {
 				Name: "test",
 			},
 			"Error parsing ConfigMap at /etc/edgedevice/config",
-			func() {},
+			func(t *testing.T) {},
 		},
 		{
 			"case 3 have empty KubeConfigPath meta new device base",
@@ -209,7 +207,7 @@ func TestNew(t *testing.T) {
 				ConfigFilePath: "etc/edgedevice/config",
 			},
 			"unable to load in-cluster configuration, KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined",
-			func() {},
+			func(t *testing.T) {},
 		},
 		{
 			"case 4 KubeConfigPath is NULL",
@@ -220,21 +218,15 @@ func TestNew(t *testing.T) {
 				Namespace:      "default",
 			},
 			"",
-			func() {
-				err := os.Setenv("", "localhost")
-				if err != nil {
-					return
-				}
-				os.Setenv("KUBERNETES_SERVICE_PORT", "1080")
-				os.Setenv("KUBERNETES_SERVICE_HOST", "127.0.0.1")
+			func(t *testing.T) {
+				t.Setenv("KUBERNETES_SERVICE_HOST", "127.0.0.1")
+				t.Setenv("KUBERNETES_SERVICE_PORT", "1080")
 			},
 		},
 	}
 	for _, c := range testCases {
 		t.Run(c.Name, func(t *testing.T) {
-			c.initEnv()
-			defer os.Unsetenv("KUBERNETES_SERVICE_HOST")
-			defer os.Unsetenv("KUBERNETES_SERVICE_PORT")
+			c.initEnv(t)
 			base, mux, err := New(c.metaData)
 			if len(c.expErrStr) > 0 {
 				assert.Equal(t, c.expErrStr, err.Error())

--- a/pkg/deviceshifu/mockdevice/mockdevice-agv/mockdevice-agv_test.go
+++ b/pkg/deviceshifu/mockdevice/mockdevice-agv/mockdevice-agv_test.go
@@ -1,14 +1,14 @@
 package main
 
 import (
-	"github.com/edgenesis/shifu/pkg/deviceshifu/mockdevice/mockdevice"
-	"github.com/stretchr/testify/assert"
 	"io"
 	"net/http"
-	"os"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/edgenesis/shifu/pkg/deviceshifu/mockdevice/mockdevice"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestInstructionHandler(t *testing.T) {
@@ -16,8 +16,8 @@ func TestInstructionHandler(t *testing.T) {
 		"get_position",
 		"get_status",
 	}
-	os.Setenv("MOCKDEVICE_NAME", "mockdevice_test")
-	os.Setenv("MOCKDEVICE_PORT", "12345")
+	t.Setenv("MOCKDEVICE_NAME", "mockdevice_test")
+	t.Setenv("MOCKDEVICE_PORT", "12345")
 	mocks := []struct {
 		name       string
 		url        string

--- a/pkg/deviceshifu/mockdevice/mockdevice-plate-reader/mockdevice-plate-reader_test.go
+++ b/pkg/deviceshifu/mockdevice/mockdevice-plate-reader/mockdevice-plate-reader_test.go
@@ -1,14 +1,14 @@
 package main
 
 import (
-	"github.com/edgenesis/shifu/pkg/deviceshifu/mockdevice/mockdevice"
-	"github.com/stretchr/testify/assert"
 	"io"
 	"net/http"
-	"os"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/edgenesis/shifu/pkg/deviceshifu/mockdevice/mockdevice"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestInstructionHandler(t *testing.T) {
@@ -16,8 +16,8 @@ func TestInstructionHandler(t *testing.T) {
 		"get_measurement",
 		"get_status",
 	}
-	os.Setenv("MOCKDEVICE_NAME", "mockdevice_test")
-	os.Setenv("MOCKDEVICE_PORT", "12345")
+	t.Setenv("MOCKDEVICE_NAME", "mockdevice_test")
+	t.Setenv("MOCKDEVICE_PORT", "12345")
 	mocks := []struct {
 		name       string
 		url        string

--- a/pkg/deviceshifu/mockdevice/mockdevice-plc/mockdevice-plc_test.go
+++ b/pkg/deviceshifu/mockdevice/mockdevice-plc/mockdevice-plc_test.go
@@ -1,14 +1,14 @@
 package main
 
 import (
-	"github.com/edgenesis/shifu/pkg/deviceshifu/mockdevice/mockdevice"
-	"github.com/stretchr/testify/assert"
 	"io"
 	"net/http"
-	"os"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/edgenesis/shifu/pkg/deviceshifu/mockdevice/mockdevice"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestInstructionHandler(t *testing.T) {
@@ -22,8 +22,8 @@ func TestInstructionHandler(t *testing.T) {
 		"sendsinglebit",
 		"get_status",
 	}
-	os.Setenv("MOCKDEVICE_NAME", "mockdevice_test")
-	os.Setenv("MOCKDEVICE_PORT", "12345")
+	t.Setenv("MOCKDEVICE_NAME", "mockdevice_test")
+	t.Setenv("MOCKDEVICE_PORT", "12345")
 	mocks := []struct {
 		name       string
 		url        string

--- a/pkg/deviceshifu/mockdevice/mockdevice-thermometer/mockdevice-thermometer_test.go
+++ b/pkg/deviceshifu/mockdevice/mockdevice-thermometer/mockdevice-thermometer_test.go
@@ -1,15 +1,15 @@
 package main
 
 import (
-	"github.com/edgenesis/shifu/pkg/deviceshifu/mockdevice/mockdevice"
-	"github.com/stretchr/testify/assert"
 	"io"
 	"net/http"
-	"os"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/edgenesis/shifu/pkg/deviceshifu/mockdevice/mockdevice"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestInstructionHandler(t *testing.T) {
@@ -17,8 +17,8 @@ func TestInstructionHandler(t *testing.T) {
 		"read_value",
 		"get_status",
 	}
-	os.Setenv("MOCKDEVICE_NAME", "mockdevice_test")
-	os.Setenv("MOCKDEVICE_PORT", "12345")
+	t.Setenv("MOCKDEVICE_NAME", "mockdevice_test")
+	t.Setenv("MOCKDEVICE_PORT", "12345")
 	mocks := []struct {
 		name       string
 		url        string

--- a/pkg/deviceshifu/mockdevice/mockdevice/mockdevice_test.go
+++ b/pkg/deviceshifu/mockdevice/mockdevice/mockdevice_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"os"
 	"testing"
 	"time"
 
@@ -12,8 +11,8 @@ import (
 )
 
 func TestStartMockDevice(t *testing.T) {
-	os.Setenv("MOCKDEVICE_NAME", "mockdevice_test")
-	os.Setenv("MOCKDEVICE_PORT", "12345")
+	t.Setenv("MOCKDEVICE_NAME", "mockdevice_test")
+	t.Setenv("MOCKDEVICE_PORT", "12345")
 	availableFuncs := []string{
 		"get_position",
 		"get_status",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

A testing cleanup.

This PR replaces `os.Setenv` with `t.Setenv`. Starting from Go 1.17, we can use `t.Setenv` to set environment variable in test. The environment variable is automatically restored to its original value when the test and all its subtests complete. This ensures that each test does not start with leftover environment variables from previous completed tests.

```go
func TestFoo(t *testing.T) {
	// before
	key := "ENV"
	originalEnv := os.Getenv(key)
	
	if err := os.Setenv(key, "new value"); err != nil {
		t.Fatal(err)
	}
	defer func() {
		if err := os.Setenv(key, originalEnv); err != nil {
			t.Logf("failed to set env %s back to original value: %v", key, err)
		}
	}()
	
	// after
	t.Setenv(key, "new value")
}
```

**Will this PR make the community happier**? 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**How is this PR tested**
- [x] unit test
- [ ] e2e test
- [ ] other (please specify)

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
