### PR TITLE
<bugFix> Handle deviceshifu stuck when responseBody is a stream

### DIFF
--- a/pkg/deviceshifu/deviceshifuhttp/deviceshifuhttp.go
+++ b/pkg/deviceshifu/deviceshifuhttp/deviceshifuhttp.go
@@ -238,10 +238,9 @@ func (handler DeviceCommandHandlerHTTP) commandHandleFunc() http.HandlerFunc {
 			}
 
 			rawRespBodyString := string(respBody)
-			respBodyString := rawRespBodyString
 			klog.Infof("Instruction %v is custom: %v", handlerInstruction, shouldUsePythonCustomProcessing)
 			klog.Infof("Instruction %v has a python customized handler configured.\n", handlerInstruction)
-			respBodyString = utils.ProcessInstruction(deviceshifubase.PythonHandlersModuleName, handlerInstruction, rawRespBodyString, deviceshifubase.PythonScriptDir)
+			respBodyString := utils.ProcessInstruction(deviceshifubase.PythonHandlersModuleName, handlerInstruction, rawRespBodyString, deviceshifubase.PythonScriptDir)
 
 			_, writeErr := io.WriteString(w, respBodyString)
 			if writeErr != nil {

--- a/pkg/deviceshifu/deviceshifuhttp/deviceshifuhttp.go
+++ b/pkg/deviceshifu/deviceshifuhttp/deviceshifuhttp.go
@@ -221,19 +221,28 @@ func (handler DeviceCommandHandlerHTTP) commandHandleFunc() http.HandlerFunc {
 			utils.CopyHeader(w.Header(), resp.Header)
 			w.WriteHeader(resp.StatusCode)
 
+			// Handling deviceshifu stuck when responseBody is a stream
+			_, shouldUsePythonCustomProcessing := deviceshifubase.CustomInstructionsPython[handlerInstruction]
+			if !shouldUsePythonCustomProcessing {
+				klog.Infof("Needn't Custom ")
+				_, err := io.Copy(w, resp.Body)
+				if err != nil {
+					klog.Errorf("cannot copy requestBody from requestBody, error: %v", err)
+				}
+				return
+			}
+
 			respBody, readErr := io.ReadAll(resp.Body)
 			if readErr != nil {
 				klog.Errorf("error when read requestBody from responseBody, err: %v", readErr)
 			}
 
 			rawRespBodyString := string(respBody)
-			_, shouldUsePythonCustomProcessing := deviceshifubase.CustomInstructionsPython[handlerInstruction]
 			respBodyString := rawRespBodyString
 			klog.Infof("Instruction %v is custom: %v", handlerInstruction, shouldUsePythonCustomProcessing)
-			if shouldUsePythonCustomProcessing {
-				klog.Infof("Instruction %v has a python customized handler configured.\n", handlerInstruction)
-				respBodyString = utils.ProcessInstruction(deviceshifubase.PythonHandlersModuleName, handlerInstruction, rawRespBodyString, deviceshifubase.PythonScriptDir)
-			}
+			klog.Infof("Instruction %v has a python customized handler configured.\n", handlerInstruction)
+			respBodyString = utils.ProcessInstruction(deviceshifubase.PythonHandlersModuleName, handlerInstruction, rawRespBodyString, deviceshifubase.PythonScriptDir)
+
 			_, writeErr := io.WriteString(w, respBodyString)
 			if writeErr != nil {
 				klog.Errorf("Failed to write response %v", respBodyString)

--- a/pkg/deviceshifu/deviceshifuhttp/deviceshifuhttp.go
+++ b/pkg/deviceshifu/deviceshifuhttp/deviceshifuhttp.go
@@ -379,22 +379,13 @@ func (handler DeviceCommandHandlerHTTPCommandline) commandHandleFunc() http.Hand
 			utils.CopyHeader(w.Header(), resp.Header)
 			w.WriteHeader(resp.StatusCode)
 
-			// Handling deviceshifu stuck when responseBody is a stream
-			_, shouldUsePythonCustomProcessing := deviceshifubase.CustomInstructionsPython[handlerInstruction]
-			if !shouldUsePythonCustomProcessing {
-				_, err := io.Copy(w, resp.Body)
-				if err != nil {
-					klog.Errorf("cannot copy requestBody from requestBody, error: %v", err)
-				}
-				return
-			}
-
 			respBody, readErr := io.ReadAll(resp.Body)
 			if readErr != nil {
 				klog.Errorf("error when read requestBody from responseBody, err: %v", readErr)
 			}
 
 			rawRespBodyString := string(respBody)
+			_, shouldUsePythonCustomProcessing := deviceshifubase.CustomInstructionsPython[handlerInstruction]
 			respBodyString := rawRespBodyString
 			klog.Infof("Instruction %v is custom: %v", handlerInstruction, shouldUsePythonCustomProcessing)
 			if shouldUsePythonCustomProcessing {

--- a/pkg/deviceshifu/deviceshifuhttp/deviceshifuhttp.go
+++ b/pkg/deviceshifu/deviceshifuhttp/deviceshifuhttp.go
@@ -224,7 +224,6 @@ func (handler DeviceCommandHandlerHTTP) commandHandleFunc() http.HandlerFunc {
 			// Handling deviceshifu stuck when responseBody is a stream
 			_, shouldUsePythonCustomProcessing := deviceshifubase.CustomInstructionsPython[handlerInstruction]
 			if !shouldUsePythonCustomProcessing {
-				klog.Infof("Needn't Custom ")
 				_, err := io.Copy(w, resp.Body)
 				if err != nil {
 					klog.Errorf("cannot copy requestBody from requestBody, error: %v", err)
@@ -238,7 +237,6 @@ func (handler DeviceCommandHandlerHTTP) commandHandleFunc() http.HandlerFunc {
 			}
 
 			rawRespBodyString := string(respBody)
-			klog.Infof("Instruction %v is custom: %v", handlerInstruction, shouldUsePythonCustomProcessing)
 			klog.Infof("Instruction %v has a python customized handler configured.\n", handlerInstruction)
 			respBodyString := utils.ProcessInstruction(deviceshifubase.PythonHandlersModuleName, handlerInstruction, rawRespBodyString, deviceshifubase.PythonScriptDir)
 

--- a/pkg/deviceshifu/deviceshifuhttp/deviceshifuhttp.go
+++ b/pkg/deviceshifu/deviceshifuhttp/deviceshifuhttp.go
@@ -379,13 +379,22 @@ func (handler DeviceCommandHandlerHTTPCommandline) commandHandleFunc() http.Hand
 			utils.CopyHeader(w.Header(), resp.Header)
 			w.WriteHeader(resp.StatusCode)
 
+			// Handling deviceshifu stuck when responseBody is a stream
+			_, shouldUsePythonCustomProcessing := deviceshifubase.CustomInstructionsPython[handlerInstruction]
+			if !shouldUsePythonCustomProcessing {
+				_, err := io.Copy(w, resp.Body)
+				if err != nil {
+					klog.Errorf("cannot copy requestBody from requestBody, error: %v", err)
+				}
+				return
+			}
+
 			respBody, readErr := io.ReadAll(resp.Body)
 			if readErr != nil {
 				klog.Errorf("error when read requestBody from responseBody, err: %v", readErr)
 			}
 
 			rawRespBodyString := string(respBody)
-			_, shouldUsePythonCustomProcessing := deviceshifubase.CustomInstructionsPython[handlerInstruction]
 			respBodyString := rawRespBodyString
 			klog.Infof("Instruction %v is custom: %v", handlerInstruction, shouldUsePythonCustomProcessing)
 			if shouldUsePythonCustomProcessing {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
Handling deviceshifu stuck when responseBody is a stream
**Will this PR make the community happier**? 
yes!!!!!!
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**How is this PR tested**
- [ ] unit test
- [ ] e2e test
- [x] other (please specify)

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
