### PR TITLE
use file redirect instead of in-place for sed in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ clean-images:
 tag:
 	go run tools/tag.go ${PROJECT_ROOT} ${IMAGE_VERSION} $(VERSION)
 	cd pkg/k8s/crd/ && (make generate-controller-yaml IMG=edgehub/shifu-controller:$(VERSION) generate-install-yaml)
-	sed -i -e "s/${IMAGE_VERSION}/${VERSION}/g" ./test/scripts/deviceshifu-demo-aio.sh
+	sed -e "s/${IMAGE_VERSION}/${VERSION}/g" ./test/scripts/deviceshifu-demo-aio.sh > ./test/scripts/tmp.sh && mv ./test/scripts/tmp.sh ./test/scripts/deviceshifu-demo-aio.sh
 	echo $(VERSION) > version.txt
 
 ## Location to install dependencies to


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
This PR updates the sed command in Makefile to use file redirect instead of in-place sed to improve compatibility for environment that has permission issue (i.e. devcontainer in VirtioFS)
**Will this PR make the community happier**? 
N/A
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**How is this PR tested**
- [ ] unit test
- [ ] e2e test
- [x] other, tested locally in devcontainer

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
- updates Makefile to remove in-place sed
```
