### PR TITLE
fix: if username is nil, initialize it.

### DIFF
--- a/pkg/deviceshifu/deviceshifubase/pushtelemetry.go
+++ b/pkg/deviceshifu/deviceshifubase/pushtelemetry.go
@@ -163,8 +163,7 @@ func injectSecret(c *rest.RESTClient, ts *v1alpha1.TelemetryService, ns string) 
 			ts.Spec.ServiceSettings.HTTPSetting.Username = new(string)
 		}
 	} else {
-		// get pointer of string
-		ts.Spec.ServiceSettings.HTTPSetting.Username = struct{ str *string }{str: &username}.str
+		ts.Spec.ServiceSettings.HTTPSetting.Username = &username
 		logger.Info("HTTPSetting.Username load from secret")
 	}
 }

--- a/pkg/deviceshifu/deviceshifubase/pushtelemetry.go
+++ b/pkg/deviceshifu/deviceshifubase/pushtelemetry.go
@@ -159,8 +159,12 @@ func injectSecret(c *rest.RESTClient, ts *v1alpha1.TelemetryService, ns string) 
 	username, exist := secret[UsernameSecretField]
 	if !exist {
 		logger.Errorf("the %v field not found in telemetry secret", UsernameSecretField)
+		if ts.Spec.ServiceSettings.HTTPSetting.Username == nil {
+			ts.Spec.ServiceSettings.HTTPSetting.Username = new(string)
+		}
 	} else {
-		*ts.Spec.ServiceSettings.HTTPSetting.Username = username
+		// get pointer of string
+		ts.Spec.ServiceSettings.HTTPSetting.Username = struct{ str *string }{str: &username}.str
 		logger.Info("HTTPSetting.Username load from secret")
 	}
 }

--- a/pkg/telemetryservice/sql/telemetryservicesql.go
+++ b/pkg/telemetryservice/sql/telemetryservicesql.go
@@ -75,8 +75,7 @@ func injectSecret(setting *v1alpha1.SQLConnectionSetting) {
 			setting.UserName = new(string)
 		}
 	} else {
-		// get pointer of string
-		setting.UserName = struct{ str *string }{str: &username}.str
+		setting.UserName = &username
 		logger.Info("SQLSetting.UserName load from secret")
 	}
 }

--- a/pkg/telemetryservice/sql/telemetryservicesql.go
+++ b/pkg/telemetryservice/sql/telemetryservicesql.go
@@ -71,8 +71,12 @@ func injectSecret(setting *v1alpha1.SQLConnectionSetting) {
 	username, exist := secret[deviceshifubase.UsernameSecretField]
 	if !exist {
 		logger.Errorf("the %v field not found in telemetry secret", deviceshifubase.UsernameSecretField)
+		if setting.UserName == nil {
+			setting.UserName = new(string)
+		}
 	} else {
-		*setting.UserName = username
+		// get pointer of string
+		setting.UserName = struct{ str *string }{str: &username}.str
 		logger.Info("SQLSetting.UserName load from secret")
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
If the user doesn't specify the username neither in telemetry setting nor secret, we may encounter a nil panic.

**Will this PR make the community happier**? 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**How is this PR tested**
- [x] unit test
- [x] e2e test
- [ ] other (please specify)

**Special notes for your reviewer**:
I don't know if there exists a better way to get the pointer of a literal string.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
