### PR TITLE
add device name to http header

### DIFF
--- a/pkg/deviceshifu/deviceshifubase/pushtelemetry.go
+++ b/pkg/deviceshifu/deviceshifubase/pushtelemetry.go
@@ -70,7 +70,7 @@ func pushToHTTPTelemetryCollectionService(message *http.Response, telemetryColle
 	}
 
 	logger.Infof("pushing %v to %v", message.Body, telemetryCollectionService)
-	utils.CopyHeader(req.Header, req.Header)
+	utils.CopyHeader(req.Header, message.Header)
 	_, err = http.DefaultClient.Do(req)
 	if err != nil {
 		logger.Errorf("HTTP POST error for telemetry service %v, error: %v", telemetryCollectionService, err.Error())
@@ -103,6 +103,7 @@ func pushToShifuTelemetryCollectionService(message *http.Response, request *v1al
 		return err
 	}
 
+	utils.CopyHeader(req.Header, message.Header)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		logger.Errorf("Error when send request to Server, error: %v", err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
Add http header to requests that httpdevice sends to telemetry. The http header contains device info.
**Will this PR make the community happier**? 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**How is this PR tested**
- [ ] unit test
- [ ] e2e test
- [ ] other (please specify)

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
