### PR TITLE
update README: capitalization

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -20,7 +20,7 @@
     Google IoT Core的开源替代
     <br />
 </h1>
-Shifu是一个k8s原生的, 生产级的,支持多协议设备接入的，开放的物联网开发平台。
+Shifu是一个K8s原生的、生产级、支持多协议设备接入、开放的物联网开发平台。
 </div>
 </div>
 <br/><br/>
@@ -35,17 +35,19 @@ Shifu是一个k8s原生的, 生产级的,支持多协议设备接入的，开放
     <a href="https://github.com/Edgenesis/shifu"><img src="https://img.shields.io/github/stars/Edgenesis/shifu?style=social" height=25></a>
 </div>
 
-# 特点
-**Kubernetes原生** — 应用开发的同时进行设备管理，无需再构建额外的运维基础设施
+## 特点
 
-**开放平台**— 避免供应商锁定，你可以轻松地将Shifu部署在公有云、私有云或混合云上。Shifu将Kubernetes带入到物联网边缘计算场景中，助力实现物联网应用程序的可扩展性和高可用性。
+* **Kubernetes原生** — 应用开发的同时进行设备管理，无需再构建额外的运维基础设施。
 
-**多协议设备接入** — HTTP, MQTT, RTSP, Siemens S7, TCP socket, OPC UA...从公有协议到私有协议，Shifu的微服务架构让我们能够快速整合接入新的协议。
+* **开放平台** — 避免供应商锁定，你可以轻松地将Shifu部署在公有云、私有云或混合云上。Shifu将Kubernetes带入到物联网边缘计算场景中，助力实现物联网应用程序的可扩展性和高可用性。
+
+* **多协议设备接入** — HTTP、MQTT、RTSP、Siemens S7、TCP Socket、OPC UA...从公有协议到私有协议，Shifu的微服务架构让我们能够快速整合接入新的协议。
 <div align="center">
 <img width="900px" src="./img/shifu-before-and-after.png"></img>
 </div>
 
-# 如何用五行代码连接一个使用私有协议的摄像头
+## 如何用五行代码连接一个使用私有协议的摄像头
+
 <div align="center">
 
 <img width="900px" src="./img/five-lines-to-connect-to-a-camera.gif"></img>
@@ -53,7 +55,7 @@ Shifu是一个k8s原生的, 生产级的,支持多协议设备接入的，开放
 <img width="900px" src="./img/star.gif"></img>
 </div>
 
-# 社区
+## 社区
 
 欢迎加入Shifu社区，分享您的思考与想法，
 
@@ -64,20 +66,24 @@ Shifu是一个k8s原生的, 生产级的,支持多协议设备接入的，开放
 [![Reddit](https://img.shields.io/badge/Reddit-post-orange)](https://www.reddit.com/r/Shifu/)
 [![GitHub Discussions](https://img.shields.io/badge/GitHub%20Discussions-post-orange)](https://github.com/Edgenesis/shifu/discussions)
 
-# 开始上手
+## 开始上手
+
 欢迎参考🗒️[Shifu技术文档](https://shifu.run/)获取更详细的信息:
 - 🔧[安装Shifu](https://shifu.run/zh-Hans/docs/guides/install/install-shifu-dev)
 - 🔌[设备连接](https://shifu.run/zh-Hans/docs/guides/cases/)
 - 👨‍💻[应用开发](https://shifu.run/zh-Hans/docs/guides/application/)
-# 贡献 
+
+## 贡献 
+
 欢迎向我们[提交issue](https://github.com/Edgenesis/shifu/issues/new/choose) 或者[提交PR](https://github.com/Edgenesis/shifu/pulls)!
 
 我们对[贡献者们](https://github.com/Edgenesis/shifu/graphs/contributors)心怀感激🥰.
 
-# Github Star数量
+## Github Star数量
 
 [![Stargazers over time](https://starchart.cc/Edgenesis/shifu.svg)](https://starchart.cc/Edgenesis/shifu)
 
-# 许可证
+## 许可证
+
 该项目使用Apache2.0许可证。
 


### PR DESCRIPTION
Correct capitalization of some terms, e.g. K8s not k8s. BTW, a post can‘t have more than one first-level title, which will affect crawling and page scoring.