### PR TITLE
replace quay.io/brancz/kube-rbac-proxy with bitnami/kube-rbac-proxy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -226,7 +226,7 @@ download-demo-files:
 	docker pull edgehub/mockdevice-thermometer:${IMAGE_VERSION}
 	docker pull edgehub/deviceshifu-http-http:${IMAGE_VERSION}
 	docker pull edgehub/shifu-controller:${IMAGE_VERSION}
-	docker pull quay.io/brancz/kube-rbac-proxy:v0.13.1
+	docker pull bitnami/kube-rbac-proxy:0.14.1
 	docker pull nginx:1.21
 
 docker-push-image-deviceshifu:

--- a/pkg/k8s/crd/config/default/manager_auth_proxy_patch.yaml
+++ b/pkg/k8s/crd/config/default/manager_auth_proxy_patch.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: quay.io/brancz/kube-rbac-proxy:v0.13.1
+        image: bitnami/kube-rbac-proxy:0.14.1
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/pkg/k8s/crd/install/config_default.yaml
+++ b/pkg/k8s/crd/install/config_default.yaml
@@ -486,7 +486,7 @@ spec:
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
         - --v=10
-        image: quay.io/brancz/kube-rbac-proxy:v0.13.1
+        image: bitnami/kube-rbac-proxy:0.14.1
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443

--- a/pkg/k8s/crd/install/shifu_install.yml
+++ b/pkg/k8s/crd/install/shifu_install.yml
@@ -486,7 +486,7 @@ spec:
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
         - --v=10
-        image: quay.io/brancz/kube-rbac-proxy:v0.13.1
+        image: bitnami/kube-rbac-proxy:0.14.1
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443

--- a/test/scripts/deviceshifu-demo-aio.sh
+++ b/test/scripts/deviceshifu-demo-aio.sh
@@ -36,7 +36,7 @@ KIND_IMG="kindest/node:v1.25.2"
 KIND_VERSION="v0.16.0"
 
 UTIL_IMG_LIST=(
-    'quay.io/brancz/kube-rbac-proxy:v0.13.1'
+    'bitnami/kube-rbac-proxy:0.14.1'
     $KIND_IMG
     'nginx:1.21'
     'eclipse-mosquitto:2.0.14'

--- a/test/scripts/deviceshifu-setup.sh
+++ b/test/scripts/deviceshifu-setup.sh
@@ -13,7 +13,7 @@ if [ "$1" == "apply" ] || [ "$1" == "delete" ]; then
                 make download-demo-files
                 kind delete cluster && kind create cluster --image=kindest/node:v1.24.0
                 kind load docker-image nginx:1.21
-                kind load docker-image quay.io/brancz/kube-rbac-proxy:v0.13.1
+                kind load docker-image bitnami/kube-rbac-proxy:0.14.1
                 kind load docker-image edgehub/deviceshifu-http-http:$TAG
                 kind load docker-image edgehub/shifu-controller:$TAG
                 kind load docker-image edgehub/mockdevice-agv:$TAG
@@ -26,7 +26,7 @@ if [ "$1" == "apply" ] || [ "$1" == "delete" ]; then
                 docker rmi $(docker images | grep 'edgehub/mockdevice' | awk '{print $3}')
                 docker rmi $(docker images | grep 'edgehub/deviceshifu-http-http' | awk '{print $3}')
                 docker rmi $(docker images | grep 'edgehub/shifu-controller' | awk '{print $3}')
-                docker rmi quay.io/brancz/kube-rbac-proxy:v0.13.1
+                docker rmi bitnami/kube-rbac-proxy:0.14.1
                 docker rmi $(docker images | grep 'kindest/node' | awk '{print $3}')
                 docker rmi nginx:1.21
         fi


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
This PR updates kube-rbac-proxy image to bitnami Docker repo to prevent quay.io connectivity issue in some region
Previously the bitnami replacement was blocked due to no arm64 image, they have added that since v0.14.0
**Will this PR make the community happier**? 
Yes
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**How is this PR tested**
- [ ] unit test
- [x] e2e test
- [ ] other (please specify)

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
- update quay.io/brancz/kube-rbac-proxy:v0.13.1 to bitnami/kube-rbac-proxy:0.14.1
```
