### PR TITLE
draft: convert DeviceShifuBase data structure

### DIFF
--- a/examples/httpDeviceShifu/deployment/http-edgedevice.yaml
+++ b/examples/httpDeviceShifu/deployment/http-edgedevice.yaml
@@ -4,7 +4,7 @@ metadata:
   name: edgedevice-http
   namespace: devices
 spec:
-  sku: "HTTP Device"
-  connection: Ethernet
-  address: 192.168.14.163:12345
-  protocol: HTTP
+  - sku: device1
+    connection: Ethernet
+    address: 192.168.11.16:12345
+    protocol: HTTP

--- a/pkg/deviceshifu/deviceshifuhttp/deviceshifuhttp_test.go
+++ b/pkg/deviceshifu/deviceshifuhttp/deviceshifuhttp_test.go
@@ -368,7 +368,7 @@ func mockDeviceShifuInstruction() *deviceshifubase.DeviceShifuInstruction {
 func TestCollectHTTPTelemtries(t *testing.T) {
 	ms := checkCustomizedTelemetryOutput(t)
 	defer ms.Close()
-	
+
 	err := makePythonCustomFile()
 	assert.Nil(t, err)
 	err = makePythonRawDataFile()
@@ -437,10 +437,10 @@ func TestCollectHTTPTelemtries(t *testing.T) {
 	res, err := mockDevice.collectHTTPTelemtries()
 	assert.Equal(t, true, res)
 	assert.Nil(t, err)
-    err = os.RemoveAll("pythoncustomizedhandlers")
-    if err != nil {
-        logger.Fatal(err)
-    }
+	err = os.RemoveAll("pythoncustomizedhandlers")
+	if err != nil {
+		logger.Fatal(err)
+	}
 }
 
 func mockTelemetryServer(t *testing.T) *httptest.Server {

--- a/pkg/k8s/api/v1alpha1/edgedevice_types.go
+++ b/pkg/k8s/api/v1alpha1/edgedevice_types.go
@@ -174,7 +174,7 @@ type EdgeDevice struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   EdgeDeviceSpec   `json:"spec,omitempty"`
+	Spec   []EdgeDeviceSpec `json:"spec,omitempty"`
 	Status EdgeDeviceStatus `json:"status,omitempty"`
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

This PR changes the DeviceShifuBase data structure from single EdgeDevice to a list type of EdgeDevice, in the EdgeDevice struct I have changed the Spec to list type. 

Line :  https://github.com/Edgenesis/shifu/blob/bf6f2848e0121b7d75d90e9be06348f40f94ee4a/pkg/k8s/api/v1alpha1/edgedevice_types.go#L177

After making this change I am unable to locate the file where I have to make changes in order to make the EdgeDeviceSpec work as a list. 

In examples/httpDeviceShifu/deployment/http-edgedevice.yaml I have added a device in the array format.

This PR points to the issue #538 

**How is this PR tested**
- [ ] unit test
- [ ] e2e test
- [ ] other (please specify)

