### PR TITLE
bump up Kind version to v0.18.0 and use Kubernetes v1.26.3 in demo

### DIFF
--- a/docs/development/develop-on-linux-zh.md
+++ b/docs/development/develop-on-linux-zh.md
@@ -57,7 +57,7 @@ echo "export PATH=$PATH:/usr/local/go/bin" >> $HOME/.profile
 从 [kind](https://kind.sigs.k8s.io/docs/user/quick-start/) 官网, 用以下命令安装:
 
 ```sh
-curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.16.0/kind-linux-amd64 \
+curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.18.0/kind-linux-amd64 \
 && chmod +x ./kind \
 && mv ./kind /usr/local/bin/kind
 ```

--- a/docs/development/develop-on-linux.md
+++ b/docs/development/develop-on-linux.md
@@ -57,7 +57,7 @@ echo "export PATH=$PATH:/usr/local/go/bin" >> $HOME/.profile
 from [kind](https://kind.sigs.k8s.io/docs/user/quick-start/), install with:
 
 ```bash
-curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.16.0/kind-linux-amd64 \
+curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.18.0/kind-linux-amd64 \
 && chmod +x ./kind \
 && mv ./kind /usr/local/bin/kind
 ```

--- a/docs/development/develop-on-windows-zh.md
+++ b/docs/development/develop-on-windows-zh.md
@@ -64,7 +64,7 @@ $ echo "export PATH=$PATH:/usr/local/go/bin" >> $HOME/.profile
 ### 1.7 安装 `kind`
 从 [kind](https://kind.sigs.k8s.io/docs/user/quick-start/) 官网, 用以下命令安装:
 ```sh
-curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.16.0/kind-linux-amd64 \
+curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.18.0/kind-linux-amd64 \
 && chmod +x ./kind \
 && mv ./kind /usr/local/bin/kind
 ```

--- a/docs/development/develop-on-windows.md
+++ b/docs/development/develop-on-windows.md
@@ -64,7 +64,7 @@ $ echo "export PATH=$PATH:/usr/local/go/bin" >> $HOME/.profile
 ### 1.7 Install `kind`
 from [kind](https://kind.sigs.k8s.io/docs/user/quick-start/), install with:
 ```sh
-curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.16.0/kind-linux-amd64 \
+curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.18.0/kind-linux-amd64 \
 && chmod +x ./kind \
 && mv ./kind /usr/local/bin/kind
 ```

--- a/test/scripts/deviceshifu-demo-aio.sh
+++ b/test/scripts/deviceshifu-demo-aio.sh
@@ -32,8 +32,8 @@ SHIFU_IMG_LIST=(
     'edgehub/mockdevice-opcua'
 )
 
-KIND_IMG="kindest/node:v1.25.2"
-KIND_VERSION="v0.16.0"
+KIND_IMG="kindest/node:v1.26.3"
+KIND_VERSION="v0.18.0"
 
 UTIL_IMG_LIST=(
     'bitnami/kube-rbac-proxy:0.14.1'


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
This PR updates kind to v0.18.0 and uses v1.26.3 for Kubernetes

**Will this PR make the community happier**? 
Yes

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**How is this PR tested**
- [ ] unit test
- [x] e2e test
- [ ] other (please specify)

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
- update kind from v0.16.0 to v0.18.0
- update Kubernetes image kindest/node to v1.26.3
```
