### PR TITLE
<BUG Fix>fix wrong type when write to opcua server

### DIFF
--- a/examples/deviceshifu/mockdevice/opcua/checkout.sh
+++ b/examples/deviceshifu/mockdevice/opcua/checkout.sh
@@ -23,7 +23,7 @@ for i in {1..5}; do
     fi
 done
 
-kubectl exec -it -n deviceshifu nginx -- curl -X POST -d "{\"value\":\"${writeData}\"}" deviceshifu-opcua/writable_value
+kubectl exec -it -n deviceshifu nginx -- curl -X POST -d "{\"value\":${writeData}}" deviceshifu-opcua/writable_value
 
 out=$(kubectl exec -it -n deviceshifu nginx -- curl deviceshifu-opcua/writable_value)
 if [[ $out -ne $writeData ]]; then

--- a/pkg/deviceshifu/deviceshifuopcua/deviceshifuopcua.go
+++ b/pkg/deviceshifu/deviceshifuopcua/deviceshifuopcua.go
@@ -291,7 +291,7 @@ func (handler DeviceCommandHandlerOPCUA) write(w http.ResponseWriter, r *http.Re
 
 	// create new value by old value's type and new value's value
 	oldValue := readResponse.Results[0].Value.Value()
-	newValue := CreateValue(oldValue, request.Value)
+	newValue := createValue(oldValue, request.Value)
 	if newValue == nil {
 		oldType := readResponse.Results[0].Value.Type().String()
 		http.Error(w, "wrong type of value, value's type should be "+oldType, http.StatusBadRequest)
@@ -427,7 +427,7 @@ func (ds *DeviceShifu) Stop() error {
 	return ds.base.Stop()
 }
 
-func CreateValue(ref interface{}, newValue interface{}) interface{} {
+func createValue(ref interface{}, newValue interface{}) interface{} {
 	refCopy := ref
 	elem := reflect.ValueOf(&refCopy).Elem()
 	if !elem.CanSet() {

--- a/pkg/deviceshifu/deviceshifuopcua/deviceshifuopcua.go
+++ b/pkg/deviceshifu/deviceshifuopcua/deviceshifuopcua.go
@@ -305,6 +305,7 @@ func (handler DeviceCommandHandlerOPCUA) write(w http.ResponseWriter, r *http.Re
 		http.Error(w, "Failed to parse value, error: "+err.Error(), http.StatusBadRequest)
 		return
 	}
+
 	opcuaRequest := &ua.WriteRequest{
 		NodesToWrite: []*ua.WriteValue{
 			{

--- a/pkg/deviceshifu/deviceshifuopcua/deviceshifuopcua_test.go
+++ b/pkg/deviceshifu/deviceshifuopcua/deviceshifuopcua_test.go
@@ -167,7 +167,7 @@ func TestCreateValue(t *testing.T) {
 	}
 	for _, tC := range testCases {
 		t.Run(tC.name, func(t *testing.T) {
-			output := createValue(tC.ref, tC.newValue)
+			output := convertValueToRef(tC.ref, tC.newValue)
 			assert.Equal(tC.exceptOutput, output)
 		})
 	}

--- a/pkg/deviceshifu/deviceshifuopcua/deviceshifuopcua_test.go
+++ b/pkg/deviceshifu/deviceshifuopcua/deviceshifuopcua_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/edgenesis/shifu/pkg/deviceshifu/deviceshifubase"
 	"github.com/edgenesis/shifu/pkg/deviceshifu/unitest"
 	"github.com/edgenesis/shifu/pkg/logger"
+	"github.com/stretchr/testify/assert"
 
 	"k8s.io/apimachinery/pkg/util/wait"
 )
@@ -110,5 +111,58 @@ func TestDeviceHealthHandler(t *testing.T) {
 
 	if err := mockds.Stop(); err != nil {
 		t.Errorf("unable to stop mock deviceShifu, error: %+v", err)
+	}
+}
+
+func TestCreateValue(t *testing.T) {
+	assert := assert.New(t)
+	testCases := []struct {
+		name         string
+		ref          interface{}
+		newValue     interface{}
+		exceptOutput interface{}
+	}{
+		{
+			name:         "int64 to int",
+			ref:          int(0),
+			newValue:     int64(64),
+			exceptOutput: int(64),
+		},
+		{
+			name:         "int to int16",
+			ref:          int16(0),
+			newValue:     int(64),
+			exceptOutput: int16(64),
+		},
+		{
+			name:         "int to int32",
+			ref:          int32(0),
+			newValue:     int(64),
+			exceptOutput: int32(64),
+		},
+		{
+			name:         "string to int",
+			ref:          int(0),
+			newValue:     "64",
+			exceptOutput: nil,
+		},
+		{
+			name:         "float64 to int16",
+			ref:          int16(0),
+			newValue:     float64(64.1),
+			exceptOutput: int16(64),
+		},
+		{
+			name:         "int to float32",
+			ref:          float32(0),
+			newValue:     123,
+			exceptOutput: float32(123),
+		},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.name, func(t *testing.T) {
+			output := CreateValue(tC.ref, tC.newValue)
+			assert.Equal(tC.exceptOutput, output)
+		})
 	}
 }

--- a/pkg/deviceshifu/deviceshifuopcua/deviceshifuopcua_test.go
+++ b/pkg/deviceshifu/deviceshifuopcua/deviceshifuopcua_test.go
@@ -161,7 +161,7 @@ func TestCreateValue(t *testing.T) {
 	}
 	for _, tC := range testCases {
 		t.Run(tC.name, func(t *testing.T) {
-			output := CreateValue(tC.ref, tC.newValue)
+			output := createValue(tC.ref, tC.newValue)
 			assert.Equal(tC.exceptOutput, output)
 		})
 	}

--- a/pkg/deviceshifu/deviceshifuopcua/deviceshifuopcua_test.go
+++ b/pkg/deviceshifu/deviceshifuopcua/deviceshifuopcua_test.go
@@ -158,6 +158,12 @@ func TestCreateValue(t *testing.T) {
 			newValue:     123,
 			exceptOutput: float32(123),
 		},
+		{
+			name:         "nil to nil",
+			ref:          nil,
+			newValue:     nil,
+			exceptOutput: nil,
+		},
 	}
 	for _, tC := range testCases {
 		t.Run(tC.name, func(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
this pr auto convert user input to corrent type, which same with the value in opcua server,  if cannot convert will return 400
**Will this PR make the community happier**? 
yes!
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**How is this PR tested**
- [x] unit test
- [ ] e2e test
- [x] other (please specify)
test by connect to opcua gateway
**Special notes for your reviewer**:
Hot Fix need to merge before v0.22.0 release
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
