### PR TITLE
update:kind version

### DIFF
--- a/test/scripts/deviceshifu-demo-aio.sh
+++ b/test/scripts/deviceshifu-demo-aio.sh
@@ -32,8 +32,8 @@ SHIFU_IMG_LIST=(
     'edgehub/mockdevice-opcua'
 )
 
-KIND_IMG="kindest/node:v1.27.1"
-KIND_VERSION="v0.19.0"
+KIND_IMG="kindest/node:v1.27.3"
+KIND_VERSION="v0.20.0"
 
 UTIL_IMG_LIST=(
     'bitnami/kube-rbac-proxy:0.14.1'


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
This PR updates kind to v1.27.1 and uses v1.27.3 for Kubernetes
**Will this PR make the community happier**? 
Yes
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**How is this PR tested**
- [ ] unit test
- [ ] e2e test
- [ ] other (please specify)

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
- bumps kind from v0.19.0 to v0.20.0
- update Kubernetes image kindest/node to v1.27.3
```
