### PR TITLE
add fsm config load

### DIFF
--- a/pkg/deviceshifu/deviceshifubase/configmap_snippet.yaml
+++ b/pkg/deviceshifu/deviceshifubase/configmap_snippet.yaml
@@ -42,3 +42,24 @@ data:
           intervalMs: 1000
           pushSettings:
             pushToServer: false
+  fsm: |
+    states:
+      red: 
+        actions:
+          go:
+            next_state: green
+        forbid:
+          - caution    
+      green:
+        actions:
+          caution:
+            next_state: yellow
+        forbid:
+          - stop
+      yellow:
+        actions:
+          stop:
+            next_state: red     
+        forbid:
+          - go
+    startingState: red

--- a/pkg/deviceshifu/deviceshifubase/deviceshifubase.go
+++ b/pkg/deviceshifu/deviceshifubase/deviceshifubase.go
@@ -60,6 +60,7 @@ const (
 	PythonHandlersModuleName                     = "customized_handlers"
 	PythonScriptDir                              = "pythoncustomizedhandlers"
 	ControlMsgsConfigStr                         = "controlMsgs"
+	FSMStr                                       = "fsm"
 )
 
 var (

--- a/pkg/deviceshifu/deviceshifubase/deviceshifubase_config.go
+++ b/pkg/deviceshifu/deviceshifubase/deviceshifubase_config.go
@@ -24,6 +24,7 @@ type DeviceShifuConfig struct {
 	Telemetries              *DeviceShifuTelemetries
 	CustomInstructionsPython map[string]string `yaml:"customInstructionsPython"`
 	ControlMsgs              map[string]string `yaml:"controlMsgs,omitempty"`
+	FSM                      *DeviceShifuFSM   `yaml:"fsm,omitempty"`
 }
 
 // DeviceShifuDriverProperties properties of deviceshifuDriver
@@ -98,6 +99,20 @@ type EdgeDeviceConfig struct {
 	KubeconfigPath string
 }
 
+type DeviceShifuFSM struct {
+	States        map[string]*DeviceShifuState `yaml:"states"`
+	StartingState *string                      `yaml:"startingState"`
+}
+
+type DeviceShifuState struct {
+	Actions map[string]*DeviceShifuAction `yaml:"actions"`
+	Forbid  []string                      `yaml:"forbid"`
+}
+
+type DeviceShifuAction struct {
+	NextState string `yaml:"next_state"`
+}
+
 // default value
 const (
 	DeviceInstructionInitialDelay            int64 = 3000
@@ -160,6 +175,14 @@ func NewDeviceShifuConfig(path string) (*DeviceShifuConfig, error) {
 		err = yaml.Unmarshal([]byte(controlMsgs), &dsc.ControlMsgs)
 		if err != nil {
 			logger.Errorf("Error parsing %v from ConfigMap, error: %v", ControlMsgsConfigStr, err)
+			return nil, err
+		}
+	}
+
+	if fsm, ok := cfg[FSMStr]; ok {
+		err = yaml.Unmarshal([]byte(fsm), &dsc.FSM)
+		if err != nil {
+			logger.Errorf("Error parsing %v from ConfigMap, error: %v", FSMStr, err)
 			return nil, err
 		}
 	}

--- a/pkg/deviceshifu/deviceshifubase/deviceshifubase_config_test.go
+++ b/pkg/deviceshifu/deviceshifubase/deviceshifubase_config_test.go
@@ -37,6 +37,7 @@ type ConfigMapData struct {
 		DriverProperties string `yaml:"driverProperties"`
 		Instructions     string `yaml:"instructions"`
 		Telemetries      string `yaml:"telemetries"`
+		FSM              string `yaml:"fsm"`
 	} `yaml:"data"`
 }
 
@@ -76,6 +77,30 @@ func TestNewDeviceShifuConfig(t *testing.T) {
 		},
 	}
 
+	var mockDeviceFSM = &DeviceShifuFSM{
+		States: map[string]*DeviceShifuState{
+			"red": {
+				Actions: map[string]*DeviceShifuAction{
+					"go": {NextState: "green"},
+				},
+				Forbid: []string{"caution"},
+			},
+			"green": {
+				Actions: map[string]*DeviceShifuAction{
+					"caution": {NextState: "yellow"},
+				},
+				Forbid: []string{"stop"},
+			},
+			"yellow": {
+				Actions: map[string]*DeviceShifuAction{
+					"stop": {NextState: "red"},
+				},
+				Forbid: []string{"go"},
+			},
+		},
+		StartingState: unitest.ToPointer("red"),
+	}
+
 	mockdsc, err := NewDeviceShifuConfig(MockDeviceConfigFolder)
 	if err != nil {
 		t.Errorf(err.Error())
@@ -97,6 +122,10 @@ func TestNewDeviceShifuConfig(t *testing.T) {
 		t.Errorf("Telemetries mismatch")
 	}
 
+	eq = reflect.DeepEqual(mockDeviceFSM, mockdsc.FSM)
+	if !eq {
+		t.Errorf("FSM mismatch")
+	}
 }
 
 func GenerateConfigMapFromSnippet(fileName string, folder string) error {
@@ -116,6 +145,7 @@ func GenerateConfigMapFromSnippet(fileName string, folder string) error {
 		path.Join(MockDeviceConfigFolder, ConfigmapDriverPropertiesStr): cmData.Data.DriverProperties,
 		path.Join(MockDeviceConfigFolder, ConfigmapInstructionsStr):     cmData.Data.Instructions,
 		path.Join(MockDeviceConfigFolder, ConfigmapTelemetriesStr):      cmData.Data.Telemetries,
+		path.Join(MockDeviceConfigFolder, FSMStr):                       cmData.Data.FSM,
 	}
 
 	err = os.MkdirAll(MockDeviceConfigFolder, os.ModePerm)

--- a/pkg/k8s/api/v1alpha1/edgedevice_types.go
+++ b/pkg/k8s/api/v1alpha1/edgedevice_types.go
@@ -102,6 +102,7 @@ type EdgeDeviceSpec struct {
 	ProtocolSettings *ProtocolSettings  `json:"protocolSettings,omitempty"`
 	CustomMetadata   *map[string]string `json:"customMetadata,omitempty"`
 
+	State *string `json:"state"`
 	// TODO: add other fields like disconnectTimemoutInSeconds
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
add fsm config load to deviceshifubase && complete relative unit test 
**Will this PR make the community happier**? 
yes
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**How is this PR tested**
- [x] unit test
- [ ] e2e test
- [ ] other (please specify)

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
