### PR TITLE
update build base image for PLC4X

### DIFF
--- a/dockerfiles/Dockerfile.deviceshifuPLC4X
+++ b/dockerfiles/Dockerfile.deviceshifuPLC4X
@@ -13,7 +13,7 @@ COPY pkg/deviceshifu pkg/deviceshifu
 COPY pkg/logger pkg/logger
 
 RUN apt-get update
-RUN apt-get install -y libpcap-dev
+RUN apt-get install -y libpcap-dev gcc
 
 RUN go mod download
 

--- a/dockerfiles/Dockerfile.deviceshifuPLC4X
+++ b/dockerfiles/Dockerfile.deviceshifuPLC4X
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$TARGETPLATFORM golang:1.20.2-buster as builder
+FROM --platform=$TARGETPLATFORM golang:1.22.0-bullseye as builder
 
 WORKDIR /shifu
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
This PR updates the base image for building PLC4X. This unblocked the merging of https://github.com/Edgenesis/shifu/pull/891

**Will this PR make the community happier**? 
Yes

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**How is this PR tested**
- [ ] unit test
- [x] e2e test
- [ ] other (please specify)

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
- update building base image of PLC4X from 1.20.2-buster to 1.22.0-bullseye
```
