### PR TITLE
Add Github Actions auto release workflow logic

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,9 @@ on:
       target_commitish:
         required: true
         type: string
+  schedule:
+    - cron: '30 15 * * 1' # 15:30 Mon 
+    - cron: '30 15 * * 4' # 15:30 Thu
 
 permissions:
   contents: write
@@ -22,33 +25,208 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
       - uses: actions/setup-go@v4
         with:
-          go-version: "1.22.0"
-      - name: set version
+          go-version: "1.22.x"
+      
+      - name: check correct week
+        id: check_week
         run: |
-          echo "VERSION=$(echo "${{inputs.tag_name}}" | cut -d '-' -f1)" >> "$GITHUB_ENV"
+          day_of_week=$(date +%u)
+          week_number=$(( ($(date +%s) / (60*60*24*7)) % 2 ))
+          if [ "$day_of_week" -eq 1 ] && [ "$week_number" -eq 0 ]; then
+            echo "::set-output name=RUN_WORKFLOW::true"
+          else if [ "$day_of_week" -eq 4 ] && [ "$week_number" -eq 1 ]; then
+            echo "::set-output name=RUN_WORKFLOW::true"
+          else
+            echo "::set-output name=RUN_WORKFLOW::false"
+          fi
+
+      - name: set up git
+        if: steps.check_week.outputs.RUN_WORKFLOW == 'true'
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: get latest tag
+        if: github.event_name != 'workflow_dispatch' && steps.check_week.outputs.RUN_WORKFLOW == 'true'
+        id: get_latest_tag
+        run: | 
+          git fetch --tags
+          latest_tag=$(git describe --tags `git rev-list --tags --max-count=1`)
+          echo "::set-output name=LATEST_TAG::${latest_tag}"
+
+      - name: set version by manual
+        if: github.event_name == 'workflow_dispatch' && steps.check_week.outputs.RUN_WORKFLOW == 'true'
+        id: set_version
+        run: |
+          new_tag="${{ github.event.inputs.tag_name }}"
+          current_tag="${{ github.event.inputs.previous_tag_name }}"
+          echo "NEW_TAG=${new_tag}" >> "$GITHUB_ENV"
+          echo "PREVIOUS_TAG=${current_tag}" >> "$GITHUB_ENV"
+        env:
+          GITHUB_ENV: ${{ env.GITHUB_ENV }}
+
+      - name: set version by automatic
+        if: github.event_name != 'workflow_dispatch' && steps.check_week.outputs.RUN_WORKFLOW == 'true'
+        id: set_version_auto
+        run: |
+          current_tag="${{ steps.get_latest_tag.outputs.LATEST_TAG }}"
+          current_version=$(echo "${current_tag}" | cut -d'.' -f2)
+          next_version=$((current_version + 1))
+          day_of_week=$(date +%u)
+          if [ "$day_of_week" -eq 1 ]; then
+            new_tag="v0.${next_version}.0-rc1"
+          else
+            new_tag="v0.${next_version}.0"
+          fi
+          echo "NEW_TAG=${new_tag}" >> "$GITHUB_ENV"
+          echo "PREVIOUS_TAG=${current_tag}" >> "$GITHUB_ENV"
+        env:
+          GITHUB_ENV: ${{ env.GITHUB_ENV }}
+
+      - name: parse env (for scheduled runs)
+        if: github.event_name != 'workflow_dispatch' && steps.check_week.outputs.RUN_WORKFLOW == 'true'
+        run: |
+          current_tag="${{ steps.get_latest_tag.outputs.LATEST_TAG }}"
+          current_version=$(echo "${current_tag}" | cut -d'.' -f2)
+          next_version=$((current_version + 1))
+          new_tag="v0.${next_version}.0"
+          echo "VERSION=${new_tag}" >> "$GITHUB_ENV"
+          echo "PREVIOUS_TAG=${current_tag}" >> "$GITHUB_ENV"
+          echo "Print env:VERSION and env:PREVIOUS_TAG"
+          echo "VERSION=${new_tag}"
+          echo "PREVIOUS_TAG=${current_tag}"
       - name: generate changelog
+        if: steps.check_week.outputs.RUN_WORKFLOW == 'true'
         run: |
           set -e
+          target_commitish="${{ github.event.inputs.target_commitish || 'main' }}"
           response=$(curl -L \
           -X POST \
           -H "Accept: application/vnd.github+json" \
           -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
           -H "X-GitHub-Api-Version: 2022-11-28" \
           https://api.github.com/repos/Edgenesis/shifu/releases/generate-notes \
-          -d '{"tag_name":"${{inputs.tag_name}}","target_commitish":"${{inputs.target_commitish}}","previous_tag_name":"${{inputs.previous_tag_name}}"}')
+          -d '{"tag_name":"${{ env.NEW_TAG }}","target_commitish":"'"${target_commitish}"'","previous_tag_name":"${{ env.PREVIOUS_TAG }}"}')
           echo $response
           go run tools/release/release.go "$response"
         env:
           AZURE_OPENAI_APIKEY: ${{ secrets.AZURE_OPENAI_APIKEY }}
           AZURE_OPENAI_HOST: ${{ secrets.AZURE_OPENAI_HOST }}
           DEPLOYMENT_NAME: ${{secrets.DEPLOYMENT_NAME}}
+          GITHUB_ENV: ${{ env.GITHUB_ENV }}
+
       - name: Create Pull Request
+        if: steps.check_week.outputs.RUN_WORKFLOW == 'true'
         uses: peter-evans/create-pull-request@v5
         with:
-          commit-message: add changelog for ${{env.VERSION}}
-          title: add changelog for ${{env.VERSION}}
-          body: add changelog for ${{env.VERSION}}
-          branch: changelog-${{env.VERSION}}
+          commit-message: add changelog for ${{ env.NEW_TAG }}
+          title: add changelog for ${{ env.NEW_TAG }}
+          body: add changelog for ${{ env.NEW_TAG }}
+          branch: changelog-${{ env.NEW_TAG }}
           base: main
+
+      - name: Fetch Pull Request Number
+        if: steps.check_week.outputs.RUN_WORKFLOW == 'true'
+        id: get-pr
+        run: |
+          PR_NUMBER=$(gh pr list --base main --head changelog-${{ env.NEW_TAG }} --json number --jq '.[0].number')
+          echo $PR_NUMBER
+          echo "PR_NUMBER=${PR_NUMBER}" >> $GITHUB_ENV
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Merge Pull Request
+        if: steps.check_week.outputs.RUN_WORKFLOW == 'true'
+        run: |
+          gh pr merge ${{ env.PR_NUMBER }} --auto --merge
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: read changelog content
+        if: steps.check_week.outputs.RUN_WORKFLOW == 'true'
+        id: read_changelog
+        run: |
+          echo ${{ env.NEW_TAG }}
+          changelog_file="CHANGELOG/testChangelog"
+          changelog_file="CHANGELOG/CHANGELOG-${new_tag}.md"
+          changelog_file_zh="CHANGELOG/CHANGELOG-${new_tag}-zh.md"
+          if [ -f "$changelog_file" ]; then
+            changelog_content=$(cat $changelog_file)
+          else
+            echo "Changelog file not found: $changelog_file"
+            exit 1
+          fi
+          if [ -f "$changelog_file_zh" ]; then
+            changelog_content_zh=$(cat $changelog_file_zh)
+          else
+            echo "Changelog file not found: $changelog_file_zh"
+            exit 1
+          fi
+          combined_changelog="${changelog_content}\n\n${changelog_content_zh}"
+          echo "::set-output name=CHANGELOG_CONTENT::${combined_changelog}"
+
+      - name: checkout main branch
+        if: steps.check_week.outputs.RUN_WORKFLOW == 'true'
+        run: |
+          git checkout main
+          git pull
+
+      - name: create local branch
+        if: steps.check_week.outputs.RUN_WORKFLOW == 'true'
+        run: |
+          new_tag="${{ env.NEW_TAG }}"
+          branch_name="release_${new_tag}"
+          git checkout -b $branch_name
+          echo "BRANCH_NAME=${branch_name}" >> "$GITHUB_ENV"
+
+      - name: make tag
+        if: steps.check_week.outputs.RUN_WORKFLOW == 'true'
+        run: |
+          new_tag="${{ env.NEW_TAG }}"
+          make tag VERSION="${new_tag}"
+          echo "BRANCH NAME = ${{ env.BRANCH_NAME }}"
+          git commit -am "change tag for release ${new_tag}"
+          echo "BEFORE TAG"
+          git show-ref
+          git tag ${new_tag}
+          echo "AFTER TAG"
+          git show-ref
+          git push origin ${new_tag}
+          git push origin "release_${new_tag}"
+
+      - name: determine if pre-release
+        if: steps.check_week.outputs.RUN_WORKFLOW == 'true'
+        id: determine_pre_release
+        run: |
+          day_of_week=$(date +%u)
+          if [ "$day_of_week" -eq 4 ]; then
+            echo "::set-output name=PRE_RELEASE::true"
+          else
+            echo "::set-output name=PRE_RELEASE::false"
+          fi
+
+      - name: create release
+        if: steps.check_week.outputs.RUN_WORKFLOW == 'true'
+        run: |
+          release_tag="${{ env.NEW_TAG }}"
+          echo ${release_tag}
+          changelog_content="${{ steps.read_changelog.outputs.CHANGELOG_CONTENT }}"
+          echo ${changelog_content}
+          pre_release="${{ steps.determine_pre_release.outputs.PRE_RELEASE }}"
+          if [ "$pre_release" == "true" ]; then
+            gh release create $release_tag \
+              --target main \
+              --title "$release_tag" \
+              --notes "$changelog_content" \
+              --prerelease
+          else
+            gh release create $release_tag \
+              --target main \
+              --title "$release_tag" \
+              --notes "$changelog_content"
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
Automatically compile the official version on Monday week 1 or the RC version on Thursday week 2, in a 2 week cycle. It will also automatically create the new release. 
**Will this PR make the community happier**? 
Yes
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**How is this PR tested**
- [ ] unit test
- [ ] e2e test
- [ ] other (please specify)

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
