### PR TITLE
[Issue #978] remove BUILDPLATFORM in the building stage to use default TARGETPLATFORM

### DIFF
--- a/dockerfiles/Dockerfile.deviceshifuPLC4X
+++ b/dockerfiles/Dockerfile.deviceshifuPLC4X
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM golang:1.22.0-alpine AS builder
+FROM golang:1.22.0-alpine AS builder
 
 WORKDIR /shifu
 


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
This PR fixes the issue of failing PLC4X build for main branch
**Will this PR make the community happier**? 
Yes
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #978

**How is this PR tested**
- [ ] unit test
- [ ] e2e test
- [x] locally tested on amd64

<img width="1463" alt="image" src="https://github.com/user-attachments/assets/dd7a89ab-1a8f-4b8d-916a-c9fd094bb3c8">
the failure in the screenshot was due to non-existing Docker repo, not failing

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
-  remove BUILDPLATFORM in the building stage to use default TARGETPLATFORM for PLC4X image
```
