### PR TITLE
update golang to 1.23.1, fix makefile, bump kubebuilder

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v2
         with:
-          go-version: "1.22.0"
+          go-version: "1.23.1"
       - name: Install pcap
         run: sudo apt-get install libpcap-dev
       - name: Run coverage

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.22.0
+          go-version: 1.23.1
       - name: Install pcap
         run: sudo apt-get install libpcap-dev
       - uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v4
         with:
-          go-version: "1.22.0"
+          go-version: "1.23.1"
       - name: set version
         run: |
           echo "VERSION=$(echo "${{inputs.tag_name}}" | cut -d '-' -f1)" >> "$GITHUB_ENV"

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,10 @@
 PROJECT_ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
 IMAGE_VERSION = $(shell cat version.txt)
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.25.2
+ENVTEST_K8S_VERSION = 1.31.0
+# Controller-Runtime branch `release-0.19` has the implementation of the setup-envtest's code responsible
+# for downloading the tarball from the correct location.
+ENVTEST_VERSION ?= release-0.19
 
 DEVICESHIFU_CMDS := deviceshifu/cmdhttp deviceshifu/cmdmqtt deviceshifu/cmdopcua deviceshifu/cmdplc4x deviceshifu/cmdsocket
 HTTPSTUB_CMDS := httpstub/powershellstub httpstub/sshstub
@@ -160,7 +163,7 @@ buildx-build-image-deviceshifu-http-plc4x:
 		-t edgehub/deviceshifu-http-plc4x:${IMAGE_VERSION} --load
 
 buildx-build-image-deviceshifu-tcp-tcp:
-	docker buildx build --platform=linux/$(shell go env GOARCH) -f ${PROJECT_ROOT}/dockerfiles/Dockerfile.deviceshifuTcp\
+	docker buildx build --platform=linux/$(shell go env GOARCH) -f ${PROJECT_ROOT}/dockerfiles/Dockerfile.deviceshifuTCP\
 		--build-arg PROJECT_ROOT="${PROJECT_ROOT}" ${PROJECT_ROOT} \
 		-t edgehub/deviceshifu-tcp-tcp:${IMAGE_VERSION} --load
 
@@ -263,8 +266,8 @@ CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 ENVTEST ?= $(LOCALBIN)/setup-envtest
 
 ## Tool Versions
-KUSTOMIZE_VERSION ?= v4.5.5
-CONTROLLER_TOOLS_VERSION ?= v0.14.0
+KUSTOMIZE_VERSION ?= v5.4.3
+CONTROLLER_TOOLS_VERSION ?= v0.16.3
 
 KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
 .PHONY: kustomize
@@ -278,6 +281,6 @@ $(CONTROLLER_GEN): $(LOCALBIN)
 	test -s $(LOCALBIN)/controller-gen || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-tools/cmd/controller-gen@$(CONTROLLER_TOOLS_VERSION)
 
 .PHONY: envtest
-envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
+envtest: $(ENVTEST) ## Download setup-envtest locally if necessary.
 $(ENVTEST): $(LOCALBIN)
-	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+	$(call go-install-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest,$(ENVTEST_VERSION))

--- a/azure-pipelines/azure-pipelines.yml
+++ b/azure-pipelines/azure-pipelines.yml
@@ -35,6 +35,8 @@ pr:
 variables:
   - name: tag
     value: ""
+  - name: goVersion
+    value: "1.23.1"
 
 pool:
   vmImage: "ubuntu-latest"
@@ -46,7 +48,7 @@ stages:
         steps:
           - task: GoTool@0
             inputs:
-              version: "1.22.0"
+              version: $(goVersion)
           - task: Go@0
             displayName: "go get"
             inputs:
@@ -67,7 +69,7 @@ stages:
         steps:
           - task: GoTool@0
             inputs:
-              version: "1.22.0"
+              version: $(goVersion)
           - task: Go@0
             displayName: "go get"
             inputs:
@@ -89,7 +91,7 @@ stages:
         steps:
           - task: GoTool@0
             inputs:
-              version: "1.22.0"
+              version: $(goVersion)
           - script: |
               tag=`cat version.txt` && echo "##vso[task.setvariable variable=tag]$tag"
             displayName: Set the tag name as an environment variable
@@ -170,7 +172,7 @@ stages:
         steps:
           - task: GoTool@0
             inputs:
-              version: "1.22.0"
+              version: $(goVersion)
           - script: |
               tag=`cat version.txt` && echo "##vso[task.setvariable variable=tag]$tag"
             displayName: Set the tag name as an environment variable
@@ -213,7 +215,7 @@ stages:
         steps:
           - task: GoTool@0
             inputs:
-              version: "1.22.0"
+              version: $(goVersion)
           - script: |
               tag=`cat version.txt` && echo "##vso[task.setvariable variable=tag]$tag"
             displayName: Set the tag name as an environment variable
@@ -256,7 +258,7 @@ stages:
         steps:
           - task: GoTool@0
             inputs:
-              version: "1.22.0"
+              version: $(goVersion)
           - script: |
               tag=`cat version.txt` && echo "##vso[task.setvariable variable=tag]$tag"
             displayName: Set the tag name as an environment variable
@@ -295,7 +297,7 @@ stages:
         steps:
           - task: GoTool@0
             inputs:
-              version: "1.22.0"
+              version: $(goVersion)
           - script: |
               tag=`cat version.txt` && echo "##vso[task.setvariable variable=tag]$tag"
             displayName: Set the tag name as an environment variable
@@ -349,7 +351,7 @@ stages:
         steps:
           - task: GoTool@0
             inputs:
-              version: "1.22.0"
+              version: $(goVersion)
           - script: |
               tag=`cat version.txt` && echo "##vso[task.setvariable variable=tag]$tag"
             displayName: Set the tag name as an environment variable
@@ -361,7 +363,7 @@ stages:
         steps:
           - task: GoTool@0
             inputs:
-              version: "1.22.0"
+              version: $(goVersion)
           - script: |
               tag=`cat version.txt` && echo "##vso[task.setvariable variable=tag]$tag"
             displayName: Set the tag name as an environment variable
@@ -447,7 +449,7 @@ stages:
         steps:
           - task: GoTool@0
             inputs:
-              version: "1.22.0"
+              version: $(goVersion)
           - task: Docker@2
             displayName: Login to DockerHub
             inputs:
@@ -465,7 +467,7 @@ stages:
         steps:
           - task: GoTool@0
             inputs:
-              version: "1.22.0"
+              version: $(goVersion)
           - task: Docker@2
             displayName: Login to DockerHub
             inputs:
@@ -483,7 +485,7 @@ stages:
         steps:
           - task: GoTool@0
             inputs:
-              version: "1.22.0"
+              version: $(goVersion)
           - task: Docker@2
             displayName: Login to DockerHub
             inputs:
@@ -501,7 +503,7 @@ stages:
         steps:
           - task: GoTool@0
             inputs:
-              version: "1.22.0"
+              version: $(goVersion)
           - task: Docker@2
             displayName: Login to DockerHub
             inputs:
@@ -519,7 +521,7 @@ stages:
         steps:
           - task: GoTool@0
             inputs:
-              version: "1.22.0"
+              version: $(goVersion)
           - task: Docker@2
             displayName: Login to DockerHub
             inputs:
@@ -537,7 +539,7 @@ stages:
         steps:
           - task: GoTool@0
             inputs:
-              version: "1.22.0"
+              version: $(goVersion)
           - task: Docker@2
             displayName: Login to DockerHub
             inputs:
@@ -555,7 +557,7 @@ stages:
         steps:
           - task: GoTool@0
             inputs:
-              version: "1.22.0"
+              version: $(goVersion)
           - task: Docker@2
             displayName: Login to DockerHub
             inputs:
@@ -573,7 +575,7 @@ stages:
         steps:
           - task: GoTool@0
             inputs:
-              version: "1.22.0"
+              version: $(goVersion)
           - task: Docker@2
             displayName: Login to DockerHub
             inputs:
@@ -591,7 +593,7 @@ stages:
         steps:
           - task: GoTool@0
             inputs:
-              version: "1.22.0"
+              version: $(goVersion)
           - task: Docker@2
             displayName: Login to DockerHub
             inputs:
@@ -609,7 +611,7 @@ stages:
         steps:
           - task: GoTool@0
             inputs:
-              version: "1.22.0"
+              version: $(goVersion)
           - task: Docker@2
             displayName: Login to DockerHub
             inputs:
@@ -627,7 +629,7 @@ stages:
         steps:
           - task: GoTool@0
             inputs:
-              version: "1.22.0"
+              version: $(goVersion)
           - task: Docker@2
             displayName: Login to DockerHub
             inputs:
@@ -645,7 +647,7 @@ stages:
         steps:
           - task: GoTool@0
             inputs:
-              version: "1.22.0"
+              version: $(goVersion)
           - task: Docker@2
             displayName: Login to DockerHub
             inputs:
@@ -663,7 +665,7 @@ stages:
         steps:
           - task: GoTool@0
             inputs:
-              version: "1.22.0"
+              version: $(goVersion)
           - task: Docker@2
             displayName: Login to DockerHub
             inputs:
@@ -681,7 +683,7 @@ stages:
         steps:
           - task: GoTool@0
             inputs:
-              version: "1.22.0"
+              version: $(goVersion)
           - task: Docker@2
             displayName: Login to DockerHub
             inputs:
@@ -699,7 +701,7 @@ stages:
         steps:
           - task: GoTool@0
             inputs:
-              version: "1.22.0"
+              version: $(goVersion)
           - task: Docker@2
             displayName: Login to DockerHub
             inputs:

--- a/dockerfiles/Dockerfile.deviceshifuHTTP
+++ b/dockerfiles/Dockerfile.deviceshifuHTTP
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM golang:1.22.0 as builder
+FROM --platform=$BUILDPLATFORM golang:1.23.1 AS builder
 
 WORKDIR /shifu
 

--- a/dockerfiles/Dockerfile.deviceshifuMQTT
+++ b/dockerfiles/Dockerfile.deviceshifuMQTT
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM golang:1.22.0 as builder
+FROM --platform=$BUILDPLATFORM golang:1.23.1 AS builder
 
 WORKDIR /shifu
 

--- a/dockerfiles/Dockerfile.deviceshifuOPCUA
+++ b/dockerfiles/Dockerfile.deviceshifuOPCUA
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM golang:1.22.0 as builder
+FROM --platform=$BUILDPLATFORM golang:1.23.1 AS builder
 
 WORKDIR /shifu
 

--- a/dockerfiles/Dockerfile.deviceshifuPLC4X
+++ b/dockerfiles/Dockerfile.deviceshifuPLC4X
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.22.0-alpine AS builder
+FROM golang:1.23.1-alpine AS builder
 
 WORKDIR /shifu
 

--- a/dockerfiles/Dockerfile.deviceshifuSocket
+++ b/dockerfiles/Dockerfile.deviceshifuSocket
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM golang:1.22.0 as builder
+FROM --platform=$BUILDPLATFORM golang:1.23.1 AS builder
 
 WORKDIR /shifu
 

--- a/dockerfiles/Dockerfile.deviceshifuTCP
+++ b/dockerfiles/Dockerfile.deviceshifuTCP
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM golang:1.22.0 as builder
+FROM --platform=$BUILDPLATFORM golang:1.23.1 AS builder
 
 WORKDIR /shifu
 

--- a/dockerfiles/Dockerfile.telemetryservice
+++ b/dockerfiles/Dockerfile.telemetryservice
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM golang:1.22.0 as builder
+FROM --platform=$BUILDPLATFORM golang:1.23.1 AS builder
 
 WORKDIR /shifu
 

--- a/examples/deviceshifu/customized/humidity_detector/Dockerfile
+++ b/examples/deviceshifu/customized/humidity_detector/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22.0-alpine AS builder
+FROM golang:1.23.1-alpine AS builder
 WORKDIR /humidity-detector
 COPY humidity-detector.go ./
 RUN go mod init humidity-detector

--- a/examples/deviceshifu/customized/humidity_detector/mockserver/Dockerfile
+++ b/examples/deviceshifu/customized/humidity_detector/mockserver/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22.0-alpine AS builder
+FROM golang:1.23.1-alpine AS builder
 WORKDIR /mockserver
 COPY *.go ./
 RUN go mod init mockserver

--- a/examples/deviceshifu/customized/humidity_detector/sample_deviceshifu_dockerfiles/Dockerfile.deviceshifuHTTP-Python
+++ b/examples/deviceshifu/customized/humidity_detector/sample_deviceshifu_dockerfiles/Dockerfile.deviceshifuHTTP-Python
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM golang:1.22.0 as builder
+FROM --platform=$BUILDPLATFORM golang:1.23.1 AS builder
 
 WORKDIR /shifu
 

--- a/examples/deviceshifu/hello-world-device/Dockerfile
+++ b/examples/deviceshifu/hello-world-device/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM golang:1.22.0-alpine
+FROM golang:1.23.1-alpine
 WORKDIR /app
 COPY go.mod ./
 RUN go mod download

--- a/examples/deviceshifu/high-temperature-detector-application/Dockerfile
+++ b/examples/deviceshifu/high-temperature-detector-application/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM golang:1.22.0-alpine
+FROM golang:1.23.1-alpine
 WORKDIR /app
 COPY go.mod ./
 RUN go mod download

--- a/examples/deviceshifu/mockdevice/agv/Dockerfile.mockdevice-agv
+++ b/examples/deviceshifu/mockdevice/agv/Dockerfile.mockdevice-agv
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM golang:1.22.0 as builder
+FROM --platform=$BUILDPLATFORM golang:1.23.1 AS builder
 
 WORKDIR /shifu
 

--- a/examples/deviceshifu/mockdevice/plate-reader/Dockerfile.mockdevice-plate-reader
+++ b/examples/deviceshifu/mockdevice/plate-reader/Dockerfile.mockdevice-plate-reader
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM golang:1.22.0 as builder
+FROM --platform=$BUILDPLATFORM golang:1.23.1 AS builder
 
 WORKDIR /shifu
 

--- a/examples/deviceshifu/mockdevice/plc/Dockerfile.mockdevice-plc
+++ b/examples/deviceshifu/mockdevice/plc/Dockerfile.mockdevice-plc
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM golang:1.22.0 as builder
+FROM --platform=$BUILDPLATFORM golang:1.23.1 AS builder
 
 WORKDIR /shifu
 

--- a/examples/deviceshifu/mockdevice/robot-arm/Dockerfile.mockdevice-robot-arm
+++ b/examples/deviceshifu/mockdevice/robot-arm/Dockerfile.mockdevice-robot-arm
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM golang:1.22.0 as builder
+FROM --platform=$BUILDPLATFORM golang:1.23.1 AS builder
 
 WORKDIR /shifu
 

--- a/examples/deviceshifu/mockdevice/socket/Dockerfile.mockdevice-socket
+++ b/examples/deviceshifu/mockdevice/socket/Dockerfile.mockdevice-socket
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.22.0 as builder
+FROM --platform=$BUILDPLATFORM golang:1.23.1 AS builder
 WORKDIR /shifu
 
 ENV GO111MODULE=on

--- a/examples/deviceshifu/mockdevice/thermometer/Dockerfile.mockdevice-thermometer
+++ b/examples/deviceshifu/mockdevice/thermometer/Dockerfile.mockdevice-thermometer
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM golang:1.22.0 as builder
+FROM --platform=$BUILDPLATFORM golang:1.23.1 AS builder
 
 WORKDIR /shifu
 

--- a/examples/driver_utils/simple-alpine/Dockerfile.sample
+++ b/examples/driver_utils/simple-alpine/Dockerfile.sample
@@ -1,4 +1,4 @@
-FROM golang:1.22.0 as builder
+FROM golang:1.23.1 AS builder
 
 WORKDIR /
 

--- a/examples/telemetryservice/mockclient/Dockerfile.mockclient
+++ b/examples/telemetryservice/mockclient/Dockerfile.mockclient
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.22.0 as builder
+FROM --platform=$BUILDPLATFORM golang:1.23.1 AS builder
 
 WORKDIR /mockclient
 

--- a/examples/telemetryservice/mockserver/Dockerfile.mockserver
+++ b/examples/telemetryservice/mockserver/Dockerfile.mockserver
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.22.0 as builder
+FROM --platform=$BUILDPLATFORM golang:1.23.1 AS builder
 
 WORKDIR /mockserver
 

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,6 @@
 module github.com/edgenesis/shifu
 
-go 1.22
-toolchain go1.22.5
+go 1.23.1
 
 require (
 	github.com/apache/plc4x/plc4go v0.0.0-20220929155823-14e7d8450c87

--- a/pkg/deviceshifu/utils/run_python.go
+++ b/pkg/deviceshifu/utils/run_python.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	PYTHON = "python"
+	PYTHON = "python3"
 	CMDARG = "-c"
 )
 

--- a/pkg/k8s/crd/Dockerfile
+++ b/pkg/k8s/crd/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM golang:1.22.0 as builder
+FROM --platform=$BUILDPLATFORM golang:1.23.1 AS builder
 
 ENV GO111MODULE=on
 ENV GOPRIVATE=github.com/Edgenesis

--- a/pkg/k8s/crd/Makefile
+++ b/pkg/k8s/crd/Makefile
@@ -4,7 +4,10 @@ IMG ?= controller:latest
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd"
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.24.2
+ENVTEST_K8S_VERSION = 1.31.0
+# Controller-Runtime branch `release-0.19` has the implementation of the setup-envtest's code responsible
+# for downloading the tarball from the correct location.
+ENVTEST_VERSION ?= release-0.19
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -125,8 +128,8 @@ CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 ENVTEST ?= $(LOCALBIN)/setup-envtest
 
 ## Tool Versions
-KUSTOMIZE_VERSION ?= v4.5.5
-CONTROLLER_TOOLS_VERSION ?= v0.14.0
+KUSTOMIZE_VERSION ?= v5.4.3
+CONTROLLER_TOOLS_VERSION ?= v0.16.3
 
 KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
 .PHONY: kustomize
@@ -140,6 +143,6 @@ $(CONTROLLER_GEN): $(LOCALBIN)
 	test -s $(LOCALBIN)/controller-gen || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-tools/cmd/controller-gen@$(CONTROLLER_TOOLS_VERSION)
 
 .PHONY: envtest
-envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
+envtest: $(ENVTEST) ## Download setup-envtest locally if necessary.
 $(ENVTEST): $(LOCALBIN)
-	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+	$(call go-install-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest,$(ENVTEST_VERSION))

--- a/pkg/k8s/crd/config/edgedevice/bases/shifu.edgenesis.io_edgedevices.yaml
+++ b/pkg/k8s/crd/config/edgedevice/bases/shifu.edgenesis.io_edgedevices.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.3
   name: edgedevices.shifu.edgenesis.io
 spec:
   group: shifu.edgenesis.io

--- a/pkg/k8s/crd/config/edgedevice/bases/shifu.edgenesis.io_telemetryservices.yaml
+++ b/pkg/k8s/crd/config/edgedevice/bases/shifu.edgenesis.io_telemetryservices.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.3
   name: telemetryservices.shifu.edgenesis.io
 spec:
   group: shifu.edgenesis.io
@@ -87,6 +87,10 @@ spec:
                         type: string
                       ServerAddress:
                         type: string
+                    required:
+                    - Bucket
+                    - FileExtension
+                    - ServerAddress
                     type: object
                   SQLSetting:
                     properties:
@@ -102,6 +106,8 @@ spec:
                         type: string
                       username:
                         type: string
+                    required:
+                    - serverAddress
                     type: object
                 type: object
               telemetryServiceEndpoint:

--- a/pkg/k8s/crd/config/rbac/role.yaml
+++ b/pkg/k8s/crd/config/rbac/role.yaml
@@ -8,31 +8,6 @@ rules:
   - shifu.edgenesis.io
   resources:
   - edgedevices
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - shifu.edgenesis.io
-  resources:
-  - edgedevices/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - shifu.edgenesis.io
-  resources:
-  - edgedevices/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - shifu.edgenesis.io
-  resources:
   - telemetryservices
   verbs:
   - create
@@ -45,12 +20,14 @@ rules:
 - apiGroups:
   - shifu.edgenesis.io
   resources:
+  - edgedevices/finalizers
   - telemetryservices/finalizers
   verbs:
   - update
 - apiGroups:
   - shifu.edgenesis.io
   resources:
+  - edgedevices/status
   - telemetryservices/status
   verbs:
   - get

--- a/pkg/k8s/crd/install/config_crd.yaml
+++ b/pkg/k8s/crd/install/config_crd.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.3
   name: edgedevices.shifu.edgenesis.io
 spec:
   group: shifu.edgenesis.io
@@ -148,7 +148,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.3
   name: telemetryservices.shifu.edgenesis.io
 spec:
   group: shifu.edgenesis.io
@@ -232,6 +232,10 @@ spec:
                         type: string
                       ServerAddress:
                         type: string
+                    required:
+                    - Bucket
+                    - FileExtension
+                    - ServerAddress
                     type: object
                   SQLSetting:
                     properties:
@@ -247,6 +251,8 @@ spec:
                         type: string
                       username:
                         type: string
+                    required:
+                    - serverAddress
                     type: object
                 type: object
               telemetryServiceEndpoint:

--- a/pkg/k8s/crd/install/config_default.yaml
+++ b/pkg/k8s/crd/install/config_default.yaml
@@ -9,7 +9,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.3
   name: edgedevices.shifu.edgenesis.io
 spec:
   group: shifu.edgenesis.io
@@ -155,7 +155,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.3
   name: telemetryservices.shifu.edgenesis.io
 spec:
   group: shifu.edgenesis.io
@@ -239,6 +239,10 @@ spec:
                         type: string
                       ServerAddress:
                         type: string
+                    required:
+                    - Bucket
+                    - FileExtension
+                    - ServerAddress
                     type: object
                   SQLSetting:
                     properties:
@@ -254,6 +258,8 @@ spec:
                         type: string
                       username:
                         type: string
+                    required:
+                    - serverAddress
                     type: object
                 type: object
               telemetryServiceEndpoint:
@@ -327,31 +333,6 @@ rules:
   - shifu.edgenesis.io
   resources:
   - edgedevices
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - shifu.edgenesis.io
-  resources:
-  - edgedevices/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - shifu.edgenesis.io
-  resources:
-  - edgedevices/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - shifu.edgenesis.io
-  resources:
   - telemetryservices
   verbs:
   - create
@@ -364,12 +345,14 @@ rules:
 - apiGroups:
   - shifu.edgenesis.io
   resources:
+  - edgedevices/finalizers
   - telemetryservices/finalizers
   verbs:
   - update
 - apiGroups:
   - shifu.edgenesis.io
   resources:
+  - edgedevices/status
   - telemetryservices/status
   verbs:
   - get

--- a/pkg/k8s/crd/install/shifu_install.yml
+++ b/pkg/k8s/crd/install/shifu_install.yml
@@ -9,7 +9,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.3
   name: edgedevices.shifu.edgenesis.io
 spec:
   group: shifu.edgenesis.io
@@ -155,7 +155,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.3
   name: telemetryservices.shifu.edgenesis.io
 spec:
   group: shifu.edgenesis.io
@@ -239,6 +239,10 @@ spec:
                         type: string
                       ServerAddress:
                         type: string
+                    required:
+                    - Bucket
+                    - FileExtension
+                    - ServerAddress
                     type: object
                   SQLSetting:
                     properties:
@@ -254,6 +258,8 @@ spec:
                         type: string
                       username:
                         type: string
+                    required:
+                    - serverAddress
                     type: object
                 type: object
               telemetryServiceEndpoint:
@@ -327,31 +333,6 @@ rules:
   - shifu.edgenesis.io
   resources:
   - edgedevices
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - shifu.edgenesis.io
-  resources:
-  - edgedevices/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - shifu.edgenesis.io
-  resources:
-  - edgedevices/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - shifu.edgenesis.io
-  resources:
   - telemetryservices
   verbs:
   - create
@@ -364,12 +345,14 @@ rules:
 - apiGroups:
   - shifu.edgenesis.io
   resources:
+  - edgedevices/finalizers
   - telemetryservices/finalizers
   verbs:
   - update
 - apiGroups:
   - shifu.edgenesis.io
   resources:
+  - edgedevices/status
   - telemetryservices/status
   verbs:
   - get

--- a/test/scripts/deviceshifu-demo-aio.sh
+++ b/test/scripts/deviceshifu-demo-aio.sh
@@ -32,8 +32,8 @@ SHIFU_IMG_LIST=(
     'edgehub/mockdevice-opcua'
 )
 
-KIND_IMG="kindest/node:v1.27.3"
-KIND_VERSION="v0.20.0"
+KIND_IMG="kindest/node:v1.31.0"
+KIND_VERSION="v0.24.0"
 
 UTIL_IMG_LIST=(
     'bitnami/kube-rbac-proxy:0.14.1'


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
This PR bumps golang to 1.23.1
**Will this PR make the community happier**? 
Yes
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**How is this PR tested**
- [x] unit test
- [x] e2e test
- [ ] other (please specify)

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
- update golang to 1.23.1
- update all dockerfiles to use 1.23.1
- update demo script to use 1.30.0 Kubernetes
- update demo script to use v0.24.0 kind
- use python3 as default customized deviceshifu python
- update kubebuilder to v0.16.3
- update kustomize to v5.4.3
- use variable for golang version in pipeline
```
