### PR TITLE
[Issue #984] fix lint issues, update golangci-lint and action versions

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -12,8 +12,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: "1.23.1"
       - name: Install pcap
@@ -21,9 +21,10 @@ jobs:
       - name: Run coverage
         run: make test
       - name: Codecov
-        uses: codecov/codecov-action@v3.1.0
+        uses: codecov/codecov-action@v4
         with:
           files: ./coverage_tdengine.out,./coverage.out
           name: codecov-shifu
-          fail_ci_if_error: true
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }} # required
           verbose: true

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -14,14 +14,14 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v5
         with:
           go-version: 1.23.1
       - name: Install pcap
         run: sudo apt-get install libpcap-dev
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v6
         with:
           version: latest
           args: --timeout=5m

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,8 +21,8 @@ jobs:
   generate_changelog:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: "1.23.1"
       - name: set version

--- a/Makefile
+++ b/Makefile
@@ -219,7 +219,7 @@ buildx-build-image-deviceshifu: \
 
 buildx-build-image-telemetry-service:
 	docker buildx build --platform=linux/$(shell go env GOARCH) -f ${PROJECT_ROOT}/dockerfiles/Dockerfile.telemetryservice\
-		--build-arg PROJECT_ROOT="${PROJECT_ROOT}" ${PROJECT_ROOT} \
+		--build-arg PROJECT_ROOT="${PROJECT_ROOT}" --build-arg GODEBUG=x509negativeserial=1 ${PROJECT_ROOT} \
 		-t edgehub/telemetryservice:${IMAGE_VERSION} --load
 
 .PHONY: download-demo-files

--- a/azure-pipelines/azure-pipelines.yml
+++ b/azure-pipelines/azure-pipelines.yml
@@ -384,6 +384,9 @@ stages:
                 --name mockclient edgehub/mockclient:$(tag)
             displayName: build mockClient
           - script: |
+              docker run -itd --network host --name nginx nginx:1.21
+            displayName: docker run nginx
+          - script: |
               set -e
               docker run -itd --network host --name sqlserver -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=YourStrong@Passw0rd" \
                 --health-cmd="/opt/mssql-tools18/bin/sqlcmd -U sa -C -P YourStrong@Passw0rd -Q 'select name from sys.databases'" --health-interval=5s --health-timeout=5s --health-retries=20 \
@@ -391,9 +394,6 @@ stages:
               bash $(System.DefaultWorkingDirectory)/examples/telemetryservice/sqlserver/checkoutput.sh
               docker rm -f sqlserver
             displayName: docker run sqlserver and checkoutput
-          - script: |
-              docker run -itd --network host --name nginx nginx:1.21
-            displayName: docker run nginx
           - script: |
               docker buildx build --platform=linux/amd64 \
                 -f $(System.DefaultWorkingDirectory)/examples/telemetryservice/mockserver/Dockerfile.mockserver \

--- a/azure-pipelines/azure-pipelines.yml
+++ b/azure-pipelines/azure-pipelines.yml
@@ -384,11 +384,19 @@ stages:
                 --name mockclient edgehub/mockclient:$(tag)
             displayName: build mockClient
           - script: |
+              set -e
+              docker run -itd --network host --name sqlserver -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=YourStrong@Passw0rd" \
+                --health-cmd="/opt/mssql-tools18/bin/sqlcmd -U sa -C -P YourStrong@Passw0rd -Q 'select name from sys.databases'" --health-interval=5s --health-timeout=5s --health-retries=20 \
+                mcr.microsoft.com/mssql/server:2022-latest
+              bash $(System.DefaultWorkingDirectory)/examples/telemetryservice/sqlserver/checkoutput.sh
+              docker rm -f sqlserver
+            displayName: docker run sqlserver and checkoutput
+          - script: |
               docker buildx build --platform=linux/amd64 \
                 -f $(System.DefaultWorkingDirectory)/examples/telemetryservice/mockserver/Dockerfile.mockserver \
                 --build-arg PROJECT_ROOT="$(System.DefaultWorkingDirectory)" $(System.DefaultWorkingDirectory) \
                 -t edgehub/mockserver:$(tag) --load
-            displayName: build and run mockServer
+            displayName: build mockServer
           - script: |
               docker run -itd --network host --name nginx nginx:1.21
             displayName: docker run nginx
@@ -428,14 +436,6 @@ stages:
               bash $(System.DefaultWorkingDirectory)/examples/telemetryservice/mysql/checkoutput.sh
               docker rm -f mysql
             displayName: docker run mysql and checkoutput
-          - script: |
-              set -e
-              docker run -itd --network host --name sqlserver -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=YourStrong@Passw0rd" \
-                --health-cmd="/opt/mssql-tools18/bin/sqlcmd -U sa -C -P YourStrong@Passw0rd -Q 'select name from sys.databases'" --health-interval=5s --health-timeout=5s --health-retries=20 \
-                mcr.microsoft.com/mssql/server:2022-latest
-              bash $(System.DefaultWorkingDirectory)/examples/telemetryservice/sqlserver/checkoutput.sh
-              docker rm -f sqlserver
-            displayName: docker run sqlserver and checkoutput
 
   - stage: docker_build_muiltiarch_and_push
     condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'), not(startsWith(variables['Build.SourceBranchName'],'release')))

--- a/azure-pipelines/azure-pipelines.yml
+++ b/azure-pipelines/azure-pipelines.yml
@@ -397,8 +397,7 @@ stages:
               docker run -itd --network host --name mosquitto eclipse-mosquitto:2.0.15
               docker run -itd --network host --name mockserver edgehub/mockserver:$(tag)
               bash $(System.DefaultWorkingDirectory)/examples/telemetryservice/mqtt/checkoutput.sh
-              docker stop mosquitto mockserver
-              docker rm mosquitto mockserver
+              docker rm -f mosquitto mockserver
             displayName: e2e_test_mqtt and checkoutput
           - script: |
               set -e
@@ -411,8 +410,7 @@ stages:
               -e MQTT_PASSWORD=mosquitto \
               edgehub/mockserver:$(tag)
               bash $(System.DefaultWorkingDirectory)/examples/telemetryservice/mqtt/checkoutput_auth.sh
-              docker stop mosquitto mockserver
-              docker rm mosquitto mockserver
+              docker rm -f mosquitto mockserver
             displayName: e2e_test_mqtt_with_auth and checkoutput
           - script: |
               set -e
@@ -420,6 +418,7 @@ stages:
                 -v $(System.DefaultWorkingDirectory)/examples/telemetryservice/tdengine/init.sql:/root/init.sql \
                 tdengine/tdengine:3.0.1.4
               bash $(System.DefaultWorkingDirectory)/examples/telemetryservice/tdengine/checkoutput.sh
+              docker rm -f tdengine
             displayName: docker run tdengine and checkoutput
           - script: |
               set -e
@@ -427,13 +426,15 @@ stages:
                 --health-cmd='mysqladmin ping -h localhost -uroot' --health-interval=5s --health-timeout=5s --health-retries=20 \
                 mysql:8.1.0
               bash $(System.DefaultWorkingDirectory)/examples/telemetryservice/mysql/checkoutput.sh
+              docker rm -f mysql
             displayName: docker run mysql and checkoutput
           - script: |
               set -e
-              docker run -d -p 1433:1433 --name sqlserver -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=YourStrong@Passw0rd" \
+              docker run -itd --network host --name sqlserver -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=YourStrong@Passw0rd" \
                 --health-cmd="/opt/mssql-tools18/bin/sqlcmd -U sa -C -P YourStrong@Passw0rd -Q 'select name from sys.databases'" --health-interval=5s --health-timeout=5s --health-retries=20 \
                 mcr.microsoft.com/mssql/server:2022-latest
               bash $(System.DefaultWorkingDirectory)/examples/telemetryservice/sqlserver/checkoutput.sh
+              docker rm -f sqlserver
             displayName: docker run sqlserver and checkoutput
 
   - stage: docker_build_muiltiarch_and_push

--- a/azure-pipelines/azure-pipelines.yml
+++ b/azure-pipelines/azure-pipelines.yml
@@ -392,14 +392,14 @@ stages:
               docker rm -f sqlserver
             displayName: docker run sqlserver and checkoutput
           - script: |
+              docker run -itd --network host --name nginx nginx:1.21
+            displayName: docker run nginx
+          - script: |
               docker buildx build --platform=linux/amd64 \
                 -f $(System.DefaultWorkingDirectory)/examples/telemetryservice/mockserver/Dockerfile.mockserver \
                 --build-arg PROJECT_ROOT="$(System.DefaultWorkingDirectory)" $(System.DefaultWorkingDirectory) \
                 -t edgehub/mockserver:$(tag) --load
             displayName: build mockServer
-          - script: |
-              docker run -itd --network host --name nginx nginx:1.21
-            displayName: docker run nginx
           - script: |
               set -e
               docker run -itd --network host --name mosquitto eclipse-mosquitto:2.0.15

--- a/cmd/httpstub/powershellstub/powershellstub.go
+++ b/cmd/httpstub/powershellstub/powershellstub.go
@@ -128,11 +128,11 @@ func httpFileServeHandler(resp http.ResponseWriter, req *http.Request) {
 	} else if errors.Is(err, os.ErrNotExist) {
 		logger.Errorf("File does not exist: %v", fileLocationString)
 		resp.WriteHeader(http.StatusNotFound)
-		fmt.Fprintf(resp, "File does not exist: "+fileLocationString+"\n")
+		fmt.Fprint(resp, "File does not exist: "+fileLocationString+"\n")
 	} else {
 		logger.Errorf("File may not exist: %v", fileLocationString)
 		resp.WriteHeader(http.StatusNotFound)
-		fmt.Fprintf(resp, "File may not exist: "+fileLocationString+"\n")
+		fmt.Fprint(resp, "File may not exist: "+fileLocationString+"\n")
 	}
 }
 

--- a/dockerfiles/Dockerfile.telemetryservice
+++ b/dockerfiles/Dockerfile.telemetryservice
@@ -21,6 +21,9 @@ RUN go mod download
 # Build the Go app
 ARG TARGETOS
 ARG TARGETARCH
+ARG GODEBUG
+
+ENV GODEBUG=$GODEBUG
 
 RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -a -o /output/telemetryservice cmd/telemetryservice/main.go
 

--- a/examples/telemetryservice/mockclient/Dockerfile.mockclient
+++ b/examples/telemetryservice/mockclient/Dockerfile.mockclient
@@ -8,7 +8,7 @@ COPY go.mod go.mod
 COPY go.sum go.sum
 COPY pkg/logger pkg/logger
 
-RUN go mod download -x
+RUN go mod download
 
 RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -a \
     -o /output/mockclient \

--- a/examples/telemetryservice/mockserver/Dockerfile.mockserver
+++ b/examples/telemetryservice/mockserver/Dockerfile.mockserver
@@ -7,7 +7,7 @@ COPY go.mod go.mod
 COPY go.sum go.sum
 COPY pkg/logger pkg/logger
 
-RUN go mod download -x
+RUN go mod download
 
 RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -a \
     -o /output/mockserver \

--- a/examples/telemetryservice/sqlserver/checkoutput.sh
+++ b/examples/telemetryservice/sqlserver/checkoutput.sh
@@ -27,6 +27,5 @@ do
     then
         exit 0
     fi
-    sleep 5
 done
 exit 1

--- a/examples/telemetryservice/sqlserver/checkoutput.sh
+++ b/examples/telemetryservice/sqlserver/checkoutput.sh
@@ -27,5 +27,6 @@ do
     then
         exit 0
     fi
+    sleep 5
 done
 exit 1

--- a/pkg/deviceshifu/deviceshifubase/deviceshifubase_config_test.go
+++ b/pkg/deviceshifu/deviceshifubase/deviceshifubase_config_test.go
@@ -78,7 +78,7 @@ func TestNewDeviceShifuConfig(t *testing.T) {
 
 	mockdsc, err := NewDeviceShifuConfig(MockDeviceConfigFolder)
 	if err != nil {
-		t.Errorf(err.Error())
+		t.Errorf("Error: %v", err)
 	}
 
 	eq := reflect.DeepEqual(DriverProperties, mockdsc.DriverProperties)

--- a/pkg/deviceshifu/deviceshifuhttp/deviceshifuhttpconfig_test.go
+++ b/pkg/deviceshifu/deviceshifuhttp/deviceshifuhttpconfig_test.go
@@ -108,7 +108,7 @@ func TestNewDeviceShifuConfig(t *testing.T) {
 
 	mockdsc, err := deviceshifubase.NewDeviceShifuConfig(MockDeviceConfigFolder)
 	if err != nil {
-		t.Errorf(err.Error())
+		t.Errorf("Error: %v", err)
 	}
 
 	eq := reflect.DeepEqual(DriverProperties, mockdsc.DriverProperties)

--- a/pkg/deviceshifu/deviceshifumqtt/deviceshifumqttconfig_test.go
+++ b/pkg/deviceshifu/deviceshifumqtt/deviceshifumqttconfig_test.go
@@ -87,7 +87,7 @@ func TestNewDeviceShifuConfig(t *testing.T) {
 
 	mockdsc, err := deviceshifubase.NewDeviceShifuConfig(MockDeviceConfigFolder)
 	if err != nil {
-		t.Errorf(err.Error())
+		t.Errorf("Error: %v", err)
 	}
 
 	eq := reflect.DeepEqual(DriverProperties, mockdsc.DriverProperties)

--- a/pkg/deviceshifu/deviceshifuopcua/deviceshifuopcuaconfig_test.go
+++ b/pkg/deviceshifu/deviceshifuopcua/deviceshifuopcuaconfig_test.go
@@ -86,7 +86,7 @@ func TestNewDeviceShifuConfig(t *testing.T) {
 
 	mockdsc, err := deviceshifubase.NewDeviceShifuConfig(MockDeviceConfigFolder)
 	if err != nil {
-		t.Errorf(err.Error())
+		t.Errorf("Error: %v", err)
 	}
 
 	mockintructions := CreateOPCUAInstructions(&mockdsc.Instructions)

--- a/pkg/deviceshifu/deviceshifusocket/deviceshifusocketconfig_test.go
+++ b/pkg/deviceshifu/deviceshifusocket/deviceshifusocketconfig_test.go
@@ -62,7 +62,7 @@ func TestNewDeviceShifuConfig(t *testing.T) {
 
 	mockdsc, err := deviceshifubase.NewDeviceShifuConfig(MockDeviceConfigFolder)
 	if err != nil {
-		t.Errorf(err.Error())
+		t.Errorf("Error: %v", err)
 	}
 
 	eq := reflect.DeepEqual(DriverProperties, mockdsc.DriverProperties)

--- a/pkg/deviceshifu/deviceshifutcp/deviceshifutcp_config_test.go
+++ b/pkg/deviceshifu/deviceshifutcp/deviceshifutcp_config_test.go
@@ -61,7 +61,7 @@ func TestNewDeviceShifuConfig(t *testing.T) {
 
 	mockdsc, err := deviceshifubase.NewDeviceShifuConfig(MockDeviceConfigFolder)
 	if err != nil {
-		t.Errorf(err.Error())
+		t.Errorf("Error: %v", err)
 	}
 
 	eq := reflect.DeepEqual(DriverProperties, mockdsc.DriverProperties)

--- a/pkg/deviceshifu/mockdevice/mockdevice-agv/mockdevice-agv.go
+++ b/pkg/deviceshifu/mockdevice/mockdevice-agv/mockdevice-agv.go
@@ -29,7 +29,7 @@ func instructionHandler(functionName string) http.HandlerFunc {
 			ypos := strconv.Itoa(rand.Intn(yrange))
 			fmt.Fprintf(w, "xpos: %v, ypos: %v", xpos, ypos)
 		case "get_status":
-			fmt.Fprintf(w, mockdevice.StatusSetList[(rand.Intn(len(mockdevice.StatusSetList)))])
+			fmt.Fprint(w, mockdevice.StatusSetList[(rand.Intn(len(mockdevice.StatusSetList)))])
 		}
 	}
 }

--- a/pkg/deviceshifu/mockdevice/mockdevice-plate-reader/mockdevice-plate-reader.go
+++ b/pkg/deviceshifu/mockdevice/mockdevice-plate-reader/mockdevice-plate-reader.go
@@ -26,12 +26,12 @@ func instructionHandler(functionName string) http.HandlerFunc {
 			for i := 0; i < 8; i++ {
 				for j := 0; j < 12; j++ {
 					num := fmt.Sprintf("%.2f", rand.Float32()*readingRange)
-					fmt.Fprintf(w, num+" ")
+					fmt.Fprint(w, num+" ")
 				}
-				fmt.Fprintf(w, "\n")
+				fmt.Fprint(w, "\n")
 			}
 		case "get_status":
-			fmt.Fprintf(w, mockdevice.StatusSetList[(rand.Intn(len(mockdevice.StatusSetList)))])
+			fmt.Fprint(w, mockdevice.StatusSetList[(rand.Intn(len(mockdevice.StatusSetList)))])
 		}
 	}
 }

--- a/pkg/deviceshifu/mockdevice/mockdevice-plc/mockdevice-plc.go
+++ b/pkg/deviceshifu/mockdevice/mockdevice-plc/mockdevice-plc.go
@@ -54,7 +54,7 @@ func instructionHandler(functionName string) http.HandlerFunc {
 			}
 
 			w.WriteHeader(http.StatusOK)
-			fmt.Fprintf(w, dataStorage[rootaddress])
+			fmt.Fprint(w, dataStorage[rootaddress])
 		case "sendsinglebit":
 			query := r.URL.Query()
 			rootaddress := query.Get(rootAddress)
@@ -83,11 +83,11 @@ func instructionHandler(functionName string) http.HandlerFunc {
 			dataStorage[rootaddress] = string(responseValue)
 			logger.Infof("%v", responseValue)
 			w.WriteHeader(http.StatusOK)
-			fmt.Fprintf(w, dataStorage[rootaddress])
+			fmt.Fprint(w, dataStorage[rootaddress])
 		case "get_status":
 			rand.Seed(time.Now().UnixNano())
 			w.WriteHeader(http.StatusOK)
-			fmt.Fprintf(w, mockdevice.StatusSetList[(rand.Intn(len(mockdevice.StatusSetList)))])
+			fmt.Fprint(w, mockdevice.StatusSetList[(rand.Intn(len(mockdevice.StatusSetList)))])
 		}
 	}
 }

--- a/pkg/deviceshifu/mockdevice/mockdevice-robot-arm/mockdevice-robot-arm.go
+++ b/pkg/deviceshifu/mockdevice/mockdevice-robot-arm/mockdevice-robot-arm.go
@@ -31,7 +31,7 @@ func instructionHandler(functionName string) http.HandlerFunc {
 			zpos := strconv.Itoa(rand.Intn(zrange))
 			fmt.Fprintf(w, "xpos: %v, ypos: %v, zpos: %v", xpos, ypos, zpos)
 		case "get_status":
-			fmt.Fprintf(w, mockdevice.StatusSetList[(rand.Intn(len(mockdevice.StatusSetList)))])
+			fmt.Fprint(w, mockdevice.StatusSetList[(rand.Intn(len(mockdevice.StatusSetList)))])
 		}
 	}
 }

--- a/pkg/deviceshifu/utils/utils_test.go
+++ b/pkg/deviceshifu/utils/utils_test.go
@@ -28,7 +28,7 @@ func TestCopyHeader(t *testing.T) {
 	url := "http://www.example.com"
 	resp, err := http.Get(url)
 	if err != nil {
-		t.Errorf(err.Error())
+		t.Errorf("Error: %v", err)
 	}
 	responseHeader := resp.Header
 	responseHeader2 := http.Header{}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
This PR fixes golangci lint failing issue in #984
**Will this PR make the community happier**? 
Yes
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #984

**How is this PR tested**
- [x] unit test
- [ ] e2e test
- [ ] other (please specify)

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
- fix lint issues in Shifu
- update Checkout action to v4
- update setup-go action to v5
- update golangci-lint action to v6
- use 1.22.7 for plc4x image building
- added in godebug env for telemetry service building
```
