### PR TITLE
[Issue #994] Fix inconsistent SQL Server E2E test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -219,7 +219,7 @@ buildx-build-image-deviceshifu: \
 
 buildx-build-image-telemetry-service:
 	docker buildx build --platform=linux/$(shell go env GOARCH) -f ${PROJECT_ROOT}/dockerfiles/Dockerfile.telemetryservice\
-		--build-arg PROJECT_ROOT="${PROJECT_ROOT}" --build-arg GODEBUG=x509negativeserial=1 ${PROJECT_ROOT} \
+		--build-arg PROJECT_ROOT="${PROJECT_ROOT}" ${PROJECT_ROOT} \
 		-t edgehub/telemetryservice:${IMAGE_VERSION} --load
 
 .PHONY: download-demo-files

--- a/dockerfiles/Dockerfile.telemetryservice
+++ b/dockerfiles/Dockerfile.telemetryservice
@@ -21,9 +21,6 @@ RUN go mod download
 # Build the Go app
 ARG TARGETOS
 ARG TARGETARCH
-ARG GODEBUG
-
-ENV GODEBUG=$GODEBUG
 
 RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -a -o /output/telemetryservice cmd/telemetryservice/main.go
 

--- a/go.mod
+++ b/go.mod
@@ -118,3 +118,7 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
+
+// See https://github.com/microsoft/go-mssqldb/issues/217 , https://github.com/microsoft/mssql-docker/issues/895
+// This temporary workaround is to avoid the error "x509: certificate signed by unknown authority" when connecting to Docker SQL Server DB with Go 1.23.1
+godebug x509negativeserial=1


### PR DESCRIPTION
…mages

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
This PR adds a godebug option to fix sql server e2e test
https://github.com/microsoft/mssql-docker/issues/895

**Will this PR make the community happier**? 
Yes
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #994

**How is this PR tested**
- [ ] unit test
- [x] e2e test
- [ ] other (please specify)

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
- added godebug flag with x509negativeserial=1 to allow certificates with negative serial number
```
