### PR TITLE
Temporarily remove PLC4X arm64 build until Go 1.23.3 releases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ buildx-push-image-deviceshifu-http-opcua:
 		-t edgehub/deviceshifu-http-opcua:${IMAGE_VERSION} --push
 
 buildx-push-image-deviceshifu-http-plc4x:
-	docker buildx build --platform=linux/amd64,linux/arm64 -f ${PROJECT_ROOT}/dockerfiles/Dockerfile.deviceshifuPLC4X \
+	docker buildx build --platform=linux/amd64 -f ${PROJECT_ROOT}/dockerfiles/Dockerfile.deviceshifuPLC4X \
 		--build-arg PROJECT_ROOT="${PROJECT_ROOT}" ${PROJECT_ROOT} \
 		-t edgehub/deviceshifu-http-plc4x:${IMAGE_VERSION} --push
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
This PR temporary removes PLC4X's arm64 build due to https://github.com/golang/go/issues/68976 
**Will this PR make the community happier**? 
Yes
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 

**How is this PR tested**
- [ ] unit test
- [x] e2e test
- [ ] other (please specify)

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
- Temporarily remove PLC4X arm64 build until Go 1.23.3 releases
```
