### PR TITLE
update Mac builder image to macOS-latest due to upcoming deprecation

### DIFF
--- a/azure-pipelines/azure-pipelines.yml
+++ b/azure-pipelines/azure-pipelines.yml
@@ -780,7 +780,7 @@ stages:
 
       - job: docker_push_shifu_demo_mac
         pool:
-          vmImage: "macOS-12"
+          vmImage: "macOS-latest"
         steps:
           - script: |
               brew --version


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
This PR updates Mac VM used in azure pipeline to latest version due to deprecation https://github.com/actions/runner-images/issues/10721

**Will this PR make the community happier**? 
Yes

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**How is this PR tested**
- [ ] unit test
- [ ] e2e test
- [ ] other (please specify)

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
- update azure pipeline's Mac builder from MacOS-12 to MacOS-latest(14)
```
