### PR TITLE
fix missing edgehub/deviceshifu-http-lwm2m load in pipeline

### DIFF
--- a/azure-pipelines/azure-pipelines.yml
+++ b/azure-pipelines/azure-pipelines.yml
@@ -315,6 +315,9 @@ stages:
               make buildx-build-image-deviceshifu-http-http
             displayName: build edgehub/deviceshifu-http-http
           - script: |
+              make buildx-build-image-deviceshifu-http-lwm2m
+            displayName: build edgehub/deviceshifu-http-lwm2m
+          - script: |
               make buildx-build-image-gateway-lwm2m
             displayName: build edgehub/gateway-lwm2m
           - script: |

--- a/azure-pipelines/azure-pipelines.yml
+++ b/azure-pipelines/azure-pipelines.yml
@@ -309,6 +309,9 @@ stages:
               tag=`cat version.txt` && echo "##vso[task.setvariable variable=tag]$tag"
             displayName: Set the tag name as an environment variable
           - script: |
+              make buildx-build-image-mockdevice-thermometer
+            displayName: build edgehub/mockdevice-thermometer
+          - script: |
               make buildx-build-image-shifu-controller
             displayName: build edgehub/shifu-controller
           - script: |
@@ -324,6 +327,7 @@ stages:
               set -e
               kind --version
               kind delete cluster && kind create cluster
+              kind load docker-image edgehub/mockdevice-thermometer:$(tag)
               kind load docker-image edgehub/shifu-controller:$(tag)  
               kind load docker-image edgehub/deviceshifu-http-http:$(tag)
               kind load docker-image edgehub/gateway-lwm2m:$(tag)

--- a/azure-pipelines/azure-pipelines.yml
+++ b/azure-pipelines/azure-pipelines.yml
@@ -324,6 +324,7 @@ stages:
               kind load docker-image edgehub/shifu-controller:$(tag)  
               kind load docker-image edgehub/deviceshifu-http-http:$(tag)
               kind load docker-image edgehub/gateway-lwm2m:$(tag)
+              kind load docker-image edgehub/deviceshifu-http-lwm2m:$(tag)
 
               kubectl version
               kubectl apply -f $(System.DefaultWorkingDirectory)/pkg/k8s/crd/install/shifu_install.yml

--- a/examples/deviceshifu/mockdevice/lwm2m-http/checkoutput.sh
+++ b/examples/deviceshifu/mockdevice/lwm2m-http/checkoutput.sh
@@ -11,7 +11,7 @@ get_value() {
 }
 
 # Attempt to get the value with retries
-for i in {1..5}; do
+for i in {1..15}; do
     out=$(get_value)
     
     # Remove any whitespace and newline characters

--- a/examples/deviceshifu/mockdevice/lwm2m-http/checkoutput.sh
+++ b/examples/deviceshifu/mockdevice/lwm2m-http/checkoutput.sh
@@ -25,12 +25,12 @@ for i in {1..15}; do
         break
     fi
     
-    echo "Device is unhealthy. Attempting to reconnect... ($i/5)"
+    echo "Device is unhealthy. Attempting to reconnect... ($i/15)"
     sleep 3
 done
 
 if [[ -z "$out" || $out == "Error on reading object" ]]; then
-    echo "Device is still unhealthy after 5 attempts. Exiting..."
+    echo "Device is still unhealthy after 15 attempts. Exiting..."
     kubectl logs -n deviceshifu $pod_name
     exit 1
 fi


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
This PR adds edgehub/deviceshifu-http-lwm2m loading in pipeline to fix failing pipeline
**Will this PR make the community happier**? 
Yes
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**How is this PR tested**
- [ ] unit test
- [x] e2e test
- [ ] other (please specify)

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
- add kind load edgehub/deviceshifu-http-lwm2m in e2e test
```
