### PR TITLE
add reconnect for lwm2m gateway

### DIFF
--- a/pkg/gateway/lwm2m/client/lwm2m.go
+++ b/pkg/gateway/lwm2m/client/lwm2m.go
@@ -217,10 +217,12 @@ func (c *Client) Register() error {
 	}
 
 	// set query params for register request
+	// example: /rd?ep=shifu-gateway&lt=300&lwm2m=1.0&b=U
 	request.AddQuery(fmt.Sprintf("%s=%s", QueryParamsEndpointName, c.EndpointName))
 	request.AddQuery(fmt.Sprintf("%s=%d", QueryParamslifeTime, c.Settings.LifeTimeSec))
 	request.AddQuery(fmt.Sprintf("%s=%s", QueryParamsLwM2MVersion, lwM2MVersion))
 	request.AddQuery(fmt.Sprintf("%s=%s", QueryParamsBindingMode, defaultBindingMode))
+	// only accept text/plain
 	request.SetAccept(message.TextPlain)
 	resp, err := c.udpConnection.Do(request)
 	if err != nil {

--- a/pkg/gateway/lwm2m/client/lwm2m.go
+++ b/pkg/gateway/lwm2m/client/lwm2m.go
@@ -50,7 +50,6 @@ type Client struct {
 
 	reconnectCh chan struct{}
 	stopCh      chan struct{}
-	connected   bool
 }
 
 type Config struct {
@@ -142,7 +141,6 @@ func (c *Client) reconnect() error {
 		return err
 	}
 
-	c.connected = true
 	return nil
 }
 
@@ -153,7 +151,6 @@ func (c *Client) connect() error {
 		udpClientOpts,
 		options.WithInactivityMonitor(time.Minute, func(cc *udpClient.Conn) {
 			logger.Warn("Connection inactive, triggering reconnect")
-			c.connected = false
 			select {
 			case c.reconnectCh <- struct{}{}:
 			default:
@@ -192,7 +189,6 @@ func (c *Client) connect() error {
 	}
 
 	c.udpConnection = conn
-	c.connected = true
 	return nil
 }
 

--- a/pkg/gateway/lwm2m/client/lwm2m.go
+++ b/pkg/gateway/lwm2m/client/lwm2m.go
@@ -136,7 +136,7 @@ func (c *Client) reconnect() error {
 		return err
 	}
 
-	// Re-register with the server
+	// Update with the server
 	if err := c.Update(); err != nil {
 		return err
 	}

--- a/pkg/gateway/lwm2m/gatewaylwm2m.go
+++ b/pkg/gateway/lwm2m/gatewaylwm2m.go
@@ -155,13 +155,6 @@ func (g *Gateway) Start() error {
 		return err
 	}
 
-	// Register the client to the server
-	err := g.client.Register()
-	if err != nil {
-		logger.Errorf("Error registering client: %v", err)
-		return err
-	}
-
 	// Ping the client every pingIntervalSec seconds, by default 30 seconds
 	t := time.NewTicker(time.Second * time.Duration(g.pingIntervalSec))
 	for range t.C {

--- a/pkg/gateway/lwm2m/gatewaylwm2m.go
+++ b/pkg/gateway/lwm2m/gatewaylwm2m.go
@@ -155,15 +155,18 @@ func (g *Gateway) Start() error {
 		return err
 	}
 
-	// Ping the client every pingIntervalSec seconds, by default 30 seconds
-	t := time.NewTicker(time.Second * time.Duration(g.pingIntervalSec))
-	for range t.C {
-		if err := g.client.Ping(); err != nil {
-			logger.Errorf("Error pinging client: %v", err)
-			g.ShutDown()
-			return err
+	if g.pingIntervalSec <= 0 {
+		// Ping the client every pingIntervalSec seconds,by default disable
+		t := time.NewTicker(time.Second * time.Duration(g.pingIntervalSec))
+		for range t.C {
+			if err := g.client.Ping(); err != nil {
+				logger.Errorf("Error pinging client: %v", err)
+				g.ShutDown()
+				return err
+			}
 		}
 	}
+
 	return nil
 }
 

--- a/pkg/gateway/lwm2m/gatewaylwm2m.go
+++ b/pkg/gateway/lwm2m/gatewaylwm2m.go
@@ -155,7 +155,7 @@ func (g *Gateway) Start() error {
 		return err
 	}
 
-	if g.pingIntervalSec <= 0 {
+	if g.pingIntervalSec > 0 {
 		// Ping the client every pingIntervalSec seconds,by default disable
 		t := time.NewTicker(time.Second * time.Duration(g.pingIntervalSec))
 		for range t.C {

--- a/pkg/k8s/api/v1alpha1/edgedevice_types.go
+++ b/pkg/k8s/api/v1alpha1/edgedevice_types.go
@@ -113,7 +113,7 @@ type LwM2MSetting struct {
 	PSKIdentity  *string       `json:"pskIdentity,omitempty"`
 	PSKKey       *string       `json:"pskKey,omitempty"`
 
-	// +kubebuilder:default=30
+	// +kubebuilder:default=-1
 	PingIntervalSec int64 `json:"pingIntervalSec,omitempty"`
 	// reference https://datatracker.ietf.org/doc/html/rfc7252#section-4.8.2
 	// +kubebuilder:default=247

--- a/pkg/k8s/crd/config/edgedevice/bases/shifu.edgenesis.io_edgedevices.yaml
+++ b/pkg/k8s/crd/config/edgedevice/bases/shifu.edgenesis.io_edgedevices.yaml
@@ -73,7 +73,7 @@ spec:
                         format: int64
                         type: integer
                       pingIntervalSec:
-                        default: 30
+                        default: -1
                         format: int64
                         type: integer
                       pskIdentity:
@@ -122,7 +122,7 @@ spec:
                         format: int64
                         type: integer
                       pingIntervalSec:
-                        default: 30
+                        default: -1
                         format: int64
                         type: integer
                       pskIdentity:

--- a/pkg/k8s/crd/install/config_crd.yaml
+++ b/pkg/k8s/crd/install/config_crd.yaml
@@ -72,7 +72,7 @@ spec:
                         format: int64
                         type: integer
                       pingIntervalSec:
-                        default: 30
+                        default: -1
                         format: int64
                         type: integer
                       pskIdentity:
@@ -121,7 +121,7 @@ spec:
                         format: int64
                         type: integer
                       pingIntervalSec:
-                        default: 30
+                        default: -1
                         format: int64
                         type: integer
                       pskIdentity:

--- a/pkg/k8s/crd/install/config_default.yaml
+++ b/pkg/k8s/crd/install/config_default.yaml
@@ -79,7 +79,7 @@ spec:
                         format: int64
                         type: integer
                       pingIntervalSec:
-                        default: 30
+                        default: -1
                         format: int64
                         type: integer
                       pskIdentity:
@@ -128,7 +128,7 @@ spec:
                         format: int64
                         type: integer
                       pingIntervalSec:
-                        default: 30
+                        default: -1
                         format: int64
                         type: integer
                       pskIdentity:

--- a/pkg/k8s/crd/install/shifu_install.yml
+++ b/pkg/k8s/crd/install/shifu_install.yml
@@ -79,7 +79,7 @@ spec:
                         format: int64
                         type: integer
                       pingIntervalSec:
-                        default: 30
+                        default: -1
                         format: int64
                         type: integer
                       pskIdentity:
@@ -128,7 +128,7 @@ spec:
                         format: int64
                         type: integer
                       pingIntervalSec:
-                        default: 30
+                        default: -1
                         format: int64
                         type: integer
                       pskIdentity:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
gateway lwm2m don't support reconnect, if connectin is lost, only can reconnect it by restart deployment or pod
**Will this PR make the community happier**? 
yes
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**How is this PR tested**
- [ ] unit test
- [ ] e2e test
- [x] other (please specify)
test by local cluste, cut down and restore the network 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
