### PR TITLE
[Issue #996] Bump Go version to fix pipeline building failure

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.23.1"
+          go-version: "1.23.4"
       - name: Install pcap
         run: sudo apt-get install libpcap-dev
       - name: Run coverage

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.23.1
+          go-version: 1.23.4
       - name: Install pcap
         run: sudo apt-get install libpcap-dev
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.23.1"
+          go-version: "1.23.4"
       - name: set version
         run: |
           echo "VERSION=$(echo "${{inputs.tag_name}}" | cut -d '-' -f1)" >> "$GITHUB_ENV"

--- a/Makefile
+++ b/Makefile
@@ -176,9 +176,9 @@ buildx-build-image-deviceshifu-http-opcua:
 		-t edgehub/deviceshifu-http-opcua:${IMAGE_VERSION} --load
 
 buildx-build-image-deviceshifu-http-plc4x:
-	docker buildx build --platform=linux/$(shell go env GOARCH),linux/arm64 -f ${PROJECT_ROOT}/dockerfiles/Dockerfile.deviceshifuPLC4X\
+	docker buildx build --platform=linux/$(shell go env GOARCH) -f ${PROJECT_ROOT}/dockerfiles/Dockerfile.deviceshifuPLC4X\
 		--build-arg PROJECT_ROOT="${PROJECT_ROOT}" ${PROJECT_ROOT} \
-		-t edgehub/deviceshifu-http-plc4x:${IMAGE_VERSION}
+		-t edgehub/deviceshifu-http-plc4x:${IMAGE_VERSION} --load
 
 buildx-build-image-deviceshifu-tcp-tcp:
 	docker buildx build --platform=linux/$(shell go env GOARCH) -f ${PROJECT_ROOT}/dockerfiles/Dockerfile.deviceshifuTCP\

--- a/Makefile
+++ b/Makefile
@@ -178,7 +178,7 @@ buildx-build-image-deviceshifu-http-opcua:
 buildx-build-image-deviceshifu-http-plc4x:
 	docker buildx build --platform=linux/$(shell go env GOARCH),linux/arm64 -f ${PROJECT_ROOT}/dockerfiles/Dockerfile.deviceshifuPLC4X\
 		--build-arg PROJECT_ROOT="${PROJECT_ROOT}" ${PROJECT_ROOT} \
-		-t edgehub/deviceshifu-http-plc4x:${IMAGE_VERSION} --load
+		-t edgehub/deviceshifu-http-plc4x:${IMAGE_VERSION}
 
 buildx-build-image-deviceshifu-tcp-tcp:
 	docker buildx build --platform=linux/$(shell go env GOARCH) -f ${PROJECT_ROOT}/dockerfiles/Dockerfile.deviceshifuTCP\

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ buildx-push-image-deviceshifu-http-opcua:
 		-t edgehub/deviceshifu-http-opcua:${IMAGE_VERSION} --push
 
 buildx-push-image-deviceshifu-http-plc4x:
-	docker buildx build --platform=linux/amd64 -f ${PROJECT_ROOT}/dockerfiles/Dockerfile.deviceshifuPLC4X \
+	docker buildx build --platform=linux/amd64,linux/arm64 -f ${PROJECT_ROOT}/dockerfiles/Dockerfile.deviceshifuPLC4X \
 		--build-arg PROJECT_ROOT="${PROJECT_ROOT}" ${PROJECT_ROOT} \
 		-t edgehub/deviceshifu-http-plc4x:${IMAGE_VERSION} --push
 
@@ -136,7 +136,9 @@ buildx-push-image-deviceshifu: \
 	buildx-push-image-deviceshifu-http-socket \
 	buildx-push-image-deviceshifu-http-opcua \
 	buildx-push-image-deviceshifu-http-plc4x \
-	buildx-push-image-deviceshifu-tcp-tcp
+	buildx-push-image-deviceshifu-tcp-tcp \
+	buildx-push-image-deviceshifu-http-lwm2m \
+	buildx-push-image-gateway-lwm2m
 
 buildx-push-image-telemetry-service:
 	docker buildx build --platform=linux/amd64,linux/arm64,linux/arm -f ${PROJECT_ROOT}/dockerfiles/Dockerfile.telemetryservice \
@@ -174,7 +176,7 @@ buildx-build-image-deviceshifu-http-opcua:
 		-t edgehub/deviceshifu-http-opcua:${IMAGE_VERSION} --load
 
 buildx-build-image-deviceshifu-http-plc4x:
-	docker buildx build --platform=linux/$(shell go env GOARCH) -f ${PROJECT_ROOT}/dockerfiles/Dockerfile.deviceshifuPLC4X\
+	docker buildx build --platform=linux/$(shell go env GOARCH),linux/arm64 -f ${PROJECT_ROOT}/dockerfiles/Dockerfile.deviceshifuPLC4X\
 		--build-arg PROJECT_ROOT="${PROJECT_ROOT}" ${PROJECT_ROOT} \
 		-t edgehub/deviceshifu-http-plc4x:${IMAGE_VERSION} --load
 
@@ -231,7 +233,9 @@ buildx-build-image-deviceshifu: \
 	buildx-build-image-deviceshifu-http-socket \
 	buildx-build-image-deviceshifu-http-opcua \
 	buildx-build-image-deviceshifu-http-plc4x \
-	buildx-build-image-deviceshifu-tcp-tcp
+	buildx-build-image-deviceshifu-tcp-tcp \
+	buildx-build-image-deviceshifu-http-lwm2m \
+	buildx-build-image-gateway-lwm2m
 
 buildx-build-image-telemetry-service:
 	docker buildx build --platform=linux/$(shell go env GOARCH) -f ${PROJECT_ROOT}/dockerfiles/Dockerfile.telemetryservice\

--- a/azure-pipelines/azure-pipelines.yml
+++ b/azure-pipelines/azure-pipelines.yml
@@ -451,6 +451,8 @@ stages:
               tag=`cat version.txt` && echo "##vso[task.setvariable variable=tag]$tag"
             displayName: Set the tag name as an environment variable
           - script: |
+              docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+              docker buildx create --use
               make buildx-build-image-deviceshifu-http-plc4x
             displayName: build edgehub/deviceshifu-http-plc4x
 

--- a/azure-pipelines/azure-pipelines.yml
+++ b/azure-pipelines/azure-pipelines.yml
@@ -36,7 +36,7 @@ variables:
   - name: tag
     value: ""
   - name: goVersion
-    value: "1.23.1"
+    value: "1.23.4"
 
 pool:
   vmImage: "ubuntu-latest"

--- a/azure-pipelines/azure-pipelines.yml
+++ b/azure-pipelines/azure-pipelines.yml
@@ -451,8 +451,6 @@ stages:
               tag=`cat version.txt` && echo "##vso[task.setvariable variable=tag]$tag"
             displayName: Set the tag name as an environment variable
           - script: |
-              docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-              docker buildx create --use
               make buildx-build-image-deviceshifu-http-plc4x
             displayName: build edgehub/deviceshifu-http-plc4x
 

--- a/dockerfiles/Dockerfile.deviceshifuHTTP
+++ b/dockerfiles/Dockerfile.deviceshifuHTTP
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM golang:1.23.1 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.23.4 AS builder
 
 WORKDIR /shifu
 

--- a/dockerfiles/Dockerfile.deviceshifuLwM2M
+++ b/dockerfiles/Dockerfile.deviceshifuLwM2M
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM golang:1.23.1 as builder
+FROM --platform=$BUILDPLATFORM golang:1.23.4 as builder
 
 WORKDIR /shifu
 

--- a/dockerfiles/Dockerfile.deviceshifuMQTT
+++ b/dockerfiles/Dockerfile.deviceshifuMQTT
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM golang:1.23.1 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.23.4 AS builder
 
 WORKDIR /shifu
 

--- a/dockerfiles/Dockerfile.deviceshifuOPCUA
+++ b/dockerfiles/Dockerfile.deviceshifuOPCUA
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM golang:1.23.1 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.23.4 AS builder
 
 WORKDIR /shifu
 

--- a/dockerfiles/Dockerfile.deviceshifuPLC4X
+++ b/dockerfiles/Dockerfile.deviceshifuPLC4X
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.23.1-alpine AS builder
+FROM golang:1.23.4-alpine AS builder
 
 WORKDIR /shifu
 

--- a/dockerfiles/Dockerfile.deviceshifuSocket
+++ b/dockerfiles/Dockerfile.deviceshifuSocket
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM golang:1.23.1 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.23.4 AS builder
 
 WORKDIR /shifu
 

--- a/dockerfiles/Dockerfile.deviceshifuTCP
+++ b/dockerfiles/Dockerfile.deviceshifuTCP
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM golang:1.23.1 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.23.4 AS builder
 
 WORKDIR /shifu
 

--- a/dockerfiles/Dockerfile.gatewayLwM2M
+++ b/dockerfiles/Dockerfile.gatewayLwM2M
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM golang:1.23.1 as builder
+FROM --platform=$BUILDPLATFORM golang:1.23.4 as builder
 
 WORKDIR /shifu
 

--- a/dockerfiles/Dockerfile.telemetryservice
+++ b/dockerfiles/Dockerfile.telemetryservice
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM golang:1.23.1 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.23.4 AS builder
 
 WORKDIR /shifu
 

--- a/examples/deviceshifu/customized/humidity_detector/Dockerfile
+++ b/examples/deviceshifu/customized/humidity_detector/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23.1-alpine AS builder
+FROM golang:1.23.4-alpine AS builder
 WORKDIR /humidity-detector
 COPY humidity-detector.go ./
 RUN go mod init humidity-detector

--- a/examples/deviceshifu/customized/humidity_detector/mockserver/Dockerfile
+++ b/examples/deviceshifu/customized/humidity_detector/mockserver/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23.1-alpine AS builder
+FROM golang:1.23.4-alpine AS builder
 WORKDIR /mockserver
 COPY *.go ./
 RUN go mod init mockserver

--- a/examples/deviceshifu/customized/humidity_detector/sample_deviceshifu_dockerfiles/Dockerfile.deviceshifuHTTP-Python
+++ b/examples/deviceshifu/customized/humidity_detector/sample_deviceshifu_dockerfiles/Dockerfile.deviceshifuHTTP-Python
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM golang:1.23.1 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.23.4 AS builder
 
 WORKDIR /shifu
 

--- a/examples/deviceshifu/hello-world-device/Dockerfile
+++ b/examples/deviceshifu/hello-world-device/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM golang:1.23.1-alpine
+FROM golang:1.23.4-alpine
 WORKDIR /app
 COPY go.mod ./
 RUN go mod download

--- a/examples/deviceshifu/high-temperature-detector-application/Dockerfile
+++ b/examples/deviceshifu/high-temperature-detector-application/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM golang:1.23.1-alpine
+FROM golang:1.23.4-alpine
 WORKDIR /app
 COPY go.mod ./
 RUN go mod download

--- a/examples/deviceshifu/mockdevice/agv/Dockerfile.mockdevice-agv
+++ b/examples/deviceshifu/mockdevice/agv/Dockerfile.mockdevice-agv
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM golang:1.23.1 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.23.4 AS builder
 
 WORKDIR /shifu
 

--- a/examples/deviceshifu/mockdevice/plate-reader/Dockerfile.mockdevice-plate-reader
+++ b/examples/deviceshifu/mockdevice/plate-reader/Dockerfile.mockdevice-plate-reader
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM golang:1.23.1 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.23.4 AS builder
 
 WORKDIR /shifu
 

--- a/examples/deviceshifu/mockdevice/plc/Dockerfile.mockdevice-plc
+++ b/examples/deviceshifu/mockdevice/plc/Dockerfile.mockdevice-plc
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM golang:1.23.1 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.23.4 AS builder
 
 WORKDIR /shifu
 

--- a/examples/deviceshifu/mockdevice/robot-arm/Dockerfile.mockdevice-robot-arm
+++ b/examples/deviceshifu/mockdevice/robot-arm/Dockerfile.mockdevice-robot-arm
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM golang:1.23.1 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.23.4 AS builder
 
 WORKDIR /shifu
 

--- a/examples/deviceshifu/mockdevice/socket/Dockerfile.mockdevice-socket
+++ b/examples/deviceshifu/mockdevice/socket/Dockerfile.mockdevice-socket
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.23.1 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.23.4 AS builder
 WORKDIR /shifu
 
 ENV GO111MODULE=on

--- a/examples/deviceshifu/mockdevice/thermometer/Dockerfile.mockdevice-thermometer
+++ b/examples/deviceshifu/mockdevice/thermometer/Dockerfile.mockdevice-thermometer
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM golang:1.23.1 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.23.4 AS builder
 
 WORKDIR /shifu
 

--- a/examples/driver_utils/simple-alpine/Dockerfile.sample
+++ b/examples/driver_utils/simple-alpine/Dockerfile.sample
@@ -1,4 +1,4 @@
-FROM golang:1.23.1 AS builder
+FROM golang:1.23.4 AS builder
 
 WORKDIR /
 

--- a/examples/telemetryservice/mockclient/Dockerfile.mockclient
+++ b/examples/telemetryservice/mockclient/Dockerfile.mockclient
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.23.1 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.23.4 AS builder
 
 WORKDIR /mockclient
 

--- a/examples/telemetryservice/mockserver/Dockerfile.mockserver
+++ b/examples/telemetryservice/mockserver/Dockerfile.mockserver
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.23.1 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.23.4 AS builder
 
 WORKDIR /mockserver
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/edgenesis/shifu
 
-go 1.23.1
+go 1.23.4
 
 require (
 	github.com/apache/plc4x/plc4go v0.0.0-20220929155823-14e7d8450c87

--- a/pkg/k8s/crd/Dockerfile
+++ b/pkg/k8s/crd/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM golang:1.23.1 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.23.4 AS builder
 
 ENV GO111MODULE=on
 ENV GOPRIVATE=github.com/Edgenesis


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
This PR fixes pipeline building failure introduced since go 1.23.1
**Will this PR make the community happier**? 
Yes
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #996

**How is this PR tested**
- [ ] unit test
- [x] e2e test
- [ ] other (please specify)

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
- bump up Golang to 1.23.4
- added building commands for deviceshifu LwM2M and Gateway LwM2M
```
