### PR TITLE
[Issue #1122] Add support for HTTP PUT request in deviceShifu HTTP

### DIFF
--- a/pkg/deviceshifu/deviceshifuhttp/deviceshifuhttp.go
+++ b/pkg/deviceshifu/deviceshifuhttp/deviceshifuhttp.go
@@ -222,6 +222,7 @@ func (handler DeviceCommandHandlerHTTP) commandHandleFunc() http.HandlerFunc {
 		}
 
 		if resp != nil {
+			defer resp.Body.Close()
 			// Handling deviceshifu stuck when responseBody is a stream
 			instructionFuncName, shouldUsePythonCustomProcessing := deviceshifubase.CustomInstructionsPython[handlerInstruction]
 			if !shouldUsePythonCustomProcessing {
@@ -385,6 +386,7 @@ func (handler DeviceCommandHandlerHTTPCommandline) commandHandleFunc() http.Hand
 		}
 
 		if resp != nil {
+			defer resp.Body.Close()
 			utils.CopyHeader(w.Header(), resp.Header)
 			w.WriteHeader(resp.StatusCode)
 
@@ -463,6 +465,7 @@ func (ds *DeviceShifuHTTP) collectHTTPTelemtries() (bool, error) {
 				}
 
 				if resp != nil {
+					defer resp.Body.Close()
 					if resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices {
 						instructionFuncName, pythonCustomExist := deviceshifubase.CustomInstructionsPython[instruction]
 						if pythonCustomExist {

--- a/pkg/deviceshifu/deviceshifuhttp/deviceshifuhttp.go
+++ b/pkg/deviceshifu/deviceshifuhttp/deviceshifuhttp.go
@@ -181,7 +181,7 @@ func (handler DeviceCommandHandlerHTTP) commandHandleFunc() http.HandlerFunc {
 		}
 
 		switch reqType {
-		case http.MethodPost:
+		case http.MethodPost, http.MethodPut:
 			requestBody, parseErr = io.ReadAll(r.Body)
 			if parseErr != nil {
 				http.Error(w, "Error on parsing body", http.StatusBadRequest)

--- a/pkg/deviceshifu/deviceshifuhttp/deviceshifuhttp_test.go
+++ b/pkg/deviceshifu/deviceshifuhttp/deviceshifuhttp_test.go
@@ -251,6 +251,10 @@ func TestCommandHandleHTTPFunc(t *testing.T) {
 	r = dc.Post().Do(context.TODO())
 	assert.Nil(t, r.Error())
 
+	// test put method
+	r = dc.Put().Do(context.TODO())
+	assert.Nil(t, r.Error())
+
 	// test not supported http method case
 	r = dc.Delete().Do(context.TODO())
 	assert.Equal(t, "the server rejected our request for an unknown reason", r.Error().Error())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
This PR adds HTTP PUT request from issue #1122

**Will this PR make the community happier**? 
Yes

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1122

**How is this PR tested**
- [x] unit test
- [x] e2e test
- [ ] other (please specify)

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
- add support for HTTP PUT request
- add test for HTTP PUT request
- properly close HTTP request body
```
