### PR TITLE
Fix incorrect logger usage

### DIFF
--- a/pkg/deviceshifu/utils/utils.go
+++ b/pkg/deviceshifu/utils/utils.go
@@ -14,7 +14,7 @@ import (
 // for url.Query() cannot parse symbol like % + and etc
 func ParseHTTPGetParams(urlStr string) (map[string]string, error) {
 	var paramStr string
-	logger.Infof("url: ", urlStr)
+	logger.Infof("url: %s", urlStr)
 	url := strings.Split(urlStr, "?")
 
 	if len(url) <= 0 {


### PR DESCRIPTION
## Summary
- fix formatting for `logger.Infof` in ParseHTTPGetParams

## Testing
- `go test ./pkg/deviceshifu/utils -run Test -v`
- `go vet ./pkg/deviceshifu/utils`


------
https://chatgpt.com/codex/tasks/task_e_68410f36fde8832b9e2fe61fa6d51aa4