### PR TITLE
Fix content type for LwM2M instruction execute

### DIFF
--- a/pkg/gateway/lwm2m/gatewaylwm2m.go
+++ b/pkg/gateway/lwm2m/gatewaylwm2m.go
@@ -231,7 +231,7 @@ func (si *ShifuInstruction) Write(data interface{}) error {
 }
 
 func (si *ShifuInstruction) Execute() error {
-	resp, err := http.Post(si.Endpoint, "plain/text", nil)
+	resp, err := http.Post(si.Endpoint, "text/plain", nil)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary
- fix content-type header for ShifuInstruction.Execute
- run go vet and go test

## Testing
- `go vet ./...`
- `go test -run=^$ ./pkg/...` *(interrupted for heavy packages)*

------
https://chatgpt.com/codex/tasks/task_e_684114fc52e8832b9ac9847bbeb4e410