### PR TITLE
Fix grammar in MinIO error messages

### DIFF
--- a/pkg/telemetryservice/minio/minio.go
+++ b/pkg/telemetryservice/minio/minio.go
@@ -36,13 +36,13 @@ func BindMinIOServiceHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if request.MinIOSetting == nil {
-		logger.Errorf("MinIOSetting cant be nil")
-		http.Error(w, "MinIOSetting cant be nil", http.StatusBadRequest)
+		logger.Errorf("MinIOSetting can't be nil")
+		http.Error(w, "MinIOSetting can't be nil", http.StatusBadRequest)
 		return
 	}
 	if request.MinIOSetting.Bucket == nil || request.MinIOSetting.ServerAddress == nil || request.MinIOSetting.FileExtension == nil {
-		logger.Errorf("Bucket or EndPoint or FileExtension cant be nil")
-		http.Error(w, "Bucket or EndPoint or FileExtension cant be nil", http.StatusBadRequest)
+		logger.Errorf("Bucket or EndPoint or FileExtension can't be nil")
+		http.Error(w, "Bucket or EndPoint or FileExtension can't be nil", http.StatusBadRequest)
 		return
 	}
 	// Read MinIo AccessKey/username & SecretKey/password

--- a/pkg/telemetryservice/minio/minio_test.go
+++ b/pkg/telemetryservice/minio/minio_test.go
@@ -32,12 +32,12 @@ func TestBindMinIOServiceHandler(t *testing.T) {
 		},
 		{
 			name:        "testCase2 MinIOSetting is nil",
-			expectResp:  "MinIOSetting cant be nil\n",
+			expectResp:  "MinIOSetting can't be nil\n",
 			requestBody: &v1alpha1.TelemetryRequest{},
 		},
 		{
 			name:       "testCase3 missing parameter",
-			expectResp: "Bucket or EndPoint or FileExtension cant be nil\n",
+			expectResp: "Bucket or EndPoint or FileExtension can't be nil\n",
 			requestBody: &v1alpha1.TelemetryRequest{
 				MinIOSetting: &v1alpha1.MinIOSetting{
 					Bucket: unitest.ToPointer("test-bucket"),


### PR DESCRIPTION
## Summary
- fix `cant` -> `can't` in telemetryservice/minio errors
- update minio unit tests to expect corrected text

## Testing
- `go test ./pkg/telemetryservice/minio -run TestBindMinIOServiceHandler -count=1`
- `go test ./...` *(fails: tests aborted due to missing dependencies or environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_684114f3efcc832b82b93e33735fd158