### PR TITLE
Fix typo in HTTP handler comment

### DIFF
--- a/pkg/deviceshifu/deviceshifuhttp/deviceshifuhttp.go
+++ b/pkg/deviceshifu/deviceshifuhttp/deviceshifuhttp.go
@@ -251,7 +251,7 @@ func (handler DeviceCommandHandlerHTTP) commandHandleFunc() http.HandlerFunc {
 			return
 		}
 
-		// TODO: For now, just write tht instruction to the response
+		// TODO: For now, just write the instruction to the response
 		logger.Warnf("resp is nil")
 		_, err := w.Write([]byte(handlerInstruction))
 		if err != nil {


### PR DESCRIPTION
## Summary
- fix a small typo in DeviceShifuHTTP comment

## Testing
- `go test ./...` *(fails: pcap.h missing during build)*

------
https://chatgpt.com/codex/tasks/task_e_68411503626c832ba14d285e41560e54