### PR TITLE
Add macOS smoke pipeline stage

### DIFF
--- a/azure-pipelines/azure-pipelines.yml
+++ b/azure-pipelines/azure-pipelines.yml
@@ -42,64 +42,1009 @@ pool:
   vmImage: "ubuntu-latest"
 
 stages:
-  - stage: macos_demo_build_smoke
-    displayName: macOS Demo Build Smoke Test
+  - stage: go_test_and_kind_e2e_test
+    condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/macos-docker-smoke'))
     jobs:
-      - job: build_macos_demo
-        displayName: Build macOS Demo on Linux
+      - job: go_build_and_test
+        steps:
+          - task: GoTool@0
+            inputs:
+              version: $(goVersion)
+          - task: Go@0
+            displayName: "go get"
+            inputs:
+              command: "get"
+              arguments: "-d"
+              workingDirectory: "$(System.DefaultWorkingDirectory)/pkg/deviceshifu/deviceshifuhttp"
+          - script: |
+              sudo apt-get install libpcap-dev
+            displayName: "Install pcap"
+          - script: |
+              make build
+              make test
+            displayName: "Go build and test"
+
+      - job: go_build_and_test_windows
         pool:
-          vmImage: "ubuntu-latest"
+          vmImage: "windows-latest"
+        steps:
+          - task: GoTool@0
+            inputs:
+              version: $(goVersion)
+          - task: Go@0
+            displayName: "go get"
+            inputs:
+              command: "get"
+              arguments: "-d"
+              workingDirectory: "$(System.DefaultWorkingDirectory)/pkg/deviceshifu/deviceshifuhttp"
+          - task: Go@0
+            displayName: "go build http to powershell stub"
+            inputs:
+              command: "build"
+              workingDirectory: "$(System.DefaultWorkingDirectory)/cmd/httpstub/powershellstub"
+              arguments: "-a -o $(System.DefaultWorkingDirectory)/output/http2powershell.exe"
+          - script: |
+              START "" $(System.DefaultWorkingDirectory)/output/http2powershell.exe
+              curl.exe -d "ls" "http://localhost:11112/issue_cmd"
+            displayName: test powershell stub
+
+      - job: kind_e2e_test_http
         steps:
           - task: GoTool@0
             inputs:
               version: $(goVersion)
           - script: |
-              set -euo pipefail
-              echo '=== macOS Demo Build Smoke Test ==='
-              echo 'System info:'
-              uname -a
-              docker --version
-              go version
-              echo 'Setting up Docker buildx for multi-arch builds...'
+              tag=`cat version.txt` && echo "##vso[task.setvariable variable=tag]$tag"
+            displayName: Set the tag name as an environment variable
+          - script: |
+              make buildx-build-image-shifu-controller
+            displayName: build edgehub/shifu-controller
+          - script: |
+              make buildx-build-image-deviceshifu-http-http
+            displayName: build edgehub/deviceshifu-http-http
+          - script: |
+              make buildx-build-image-mockdevice-thermometer
+            displayName: build edgehub/mockdevice-thermometer
+          - script: |
+              make buildx-build-image-mockdevice-robot-arm
+            displayName: build edgehub/mockdevice-robot-arm
+          - script: |
+              make buildx-build-image-mockdevice-plate-reader
+            displayName: build edgehub/mockdevice-plate-reader
+          - script: |
+              make buildx-build-image-mockdevice-agv
+            displayName: build edgehub/mockdevice-agv
+          - script: |
+              make buildx-build-image-mockdevice-plc
+            displayName: build edgehub/mockdevice-plc
+          - script: |
+              set -e
+              kind --version
+              kind delete cluster && kind create cluster
+              kind load docker-image edgehub/shifu-controller:$(tag)
+              kind load docker-image edgehub/mockdevice-thermometer:$(tag)
+              kind load docker-image edgehub/mockdevice-plate-reader:$(tag)
+              kind load docker-image edgehub/mockdevice-robot-arm:$(tag)
+              kind load docker-image edgehub/mockdevice-agv:$(tag)
+              kind load docker-image edgehub/mockdevice-plc:$(tag)
+              kind load docker-image edgehub/deviceshifu-http-http:$(tag)   
+
+              kubectl version
+              kubectl apply -f $(System.DefaultWorkingDirectory)/pkg/k8s/crd/install/shifu_install.yml
+              kubectl wait --for=condition=Available deploy/shifu-crd-controller-manager -n shifu-crd-system --timeout=150s
+            displayName: "setup Kind cluster and install Shifu"
+          - script: |
+              set -e
+              kubectl run nginx --image=nginx -n deviceshifu
+              kubectl apply -f $(System.DefaultWorkingDirectory)/examples/deviceshifu/demo_device/edgedevice-plc
+              kubectl wait --for=condition=Available deploy/plc -n devices --timeout=150s
+              kubectl wait --for=condition=Available deploy/deviceshifu-plc-deployment -n deviceshifu --timeout=150s
+              sleep 5
+              kubectl wait --for condition=Ready pod/nginx -n deviceshifu --timeout=150s
+              kubectl exec -it -n deviceshifu nginx -- curl deviceshifu-plc/getcontent?rootsssaddress=Q;echo
+              kubectl delete -f $(System.DefaultWorkingDirectory)/examples/deviceshifu/demo_device/edgedevice-plc
+              kubectl apply -f $(System.DefaultWorkingDirectory)/examples/deviceshifu/demo_device/edgedevice-agv
+              kubectl wait --for=condition=Available deploy/deviceshifu-agv-deployment -n deviceshifu --timeout=150s
+              kubectl wait --for=condition=Available deploy/agv -n devices --timeout=150s
+              sleep 5
+              kubectl exec -it -n deviceshifu nginx -- curl http://deviceshifu-agv/get_position
+              kubectl delete -f $(System.DefaultWorkingDirectory)/examples/deviceshifu/demo_device/edgedevice-agv
+              kubectl apply -f $(System.DefaultWorkingDirectory)/examples/deviceshifu/demo_device/edgedevice-plate-reader
+              kubectl wait --for=condition=Available deploy/deviceshifu-plate-reader-deployment -n deviceshifu --timeout=150s
+              kubectl wait --for=condition=Available deploy/plate-reader -n devices --timeout=150s
+              sleep 5
+              kubectl exec -it -n deviceshifu nginx -- curl http://deviceshifu-plate-reader/get_measurement
+              kubectl delete -f $(System.DefaultWorkingDirectory)/examples/deviceshifu/demo_device/edgedevice-plate-reader
+              kubectl apply -f $(System.DefaultWorkingDirectory)/examples/deviceshifu/demo_device/edgedevice-robot-arm
+              kubectl wait --for=condition=Available deploy/deviceshifu-robotarm-deployment -n deviceshifu --timeout=150s
+              kubectl wait --for=condition=Available deploy/robotarm -n devices --timeout=150s
+              sleep 5    
+              kubectl exec -it -n deviceshifu nginx -- curl http://deviceshifu-robotarm/get_coordinate
+              kubectl delete -f $(System.DefaultWorkingDirectory)/examples/deviceshifu/demo_device/edgedevice-robot-arm
+              kubectl apply -f $(System.DefaultWorkingDirectory)/examples/deviceshifu/demo_device/edgedevice-thermometer
+              kubectl wait --for=condition=Available deploy/deviceshifu-thermometer-deployment -n deviceshifu --timeout=150s
+              kubectl wait --for=condition=Available deploy/thermometer -n devices --timeout=150s
+              sleep 5    
+              kubectl exec -it -n deviceshifu nginx -- curl http://deviceshifu-thermometer/read_value
+              kubectl delete -f $(System.DefaultWorkingDirectory)/examples/deviceshifu/demo_device/edgedevice-thermometer
+            displayName: "Shifu demo device HTTP E2E test"
+
+      - job: kind_e2e_test_opcua
+        steps:
+          - task: GoTool@0
+            inputs:
+              version: $(goVersion)
+          - script: |
+              tag=`cat version.txt` && echo "##vso[task.setvariable variable=tag]$tag"
+            displayName: Set the tag name as an environment variable
+          - script: |
+              make buildx-build-image-shifu-controller
+            displayName: build edgehub/shifu-controller
+          - script: |
+              make buildx-build-image-deviceshifu-http-opcua
+            displayName: build deviceshifu-http-opcua
+          - script: |
+              make buildx-build-image-mockdevice-opcua
+            displayName: build mockdevice-opcua
+          - script: |
+              set -e
+              kind --version
+              kind delete cluster && kind create cluster
+              kind load docker-image edgehub/shifu-controller:$(tag)
+              kind load docker-image edgehub/deviceshifu-http-opcua:$(tag)
+              kind load docker-image edgehub/mockdevice-opcua:$(tag)
+
+              kubectl version
+              kubectl apply -f $(System.DefaultWorkingDirectory)/pkg/k8s/crd/install/shifu_install.yml
+              kubectl wait --for=condition=Available deploy/shifu-crd-controller-manager -n shifu-crd-system --timeout=150s
+            displayName: "setup Kind cluster and install Shifu"
+          - script: |
+              set -e 
+              kubectl run nginx --image=nginx -n deviceshifu
+              kubectl apply -f $(System.DefaultWorkingDirectory)/examples/deviceshifu/demo_device/edgedevice-opcua/mock-device
+              kubectl wait --for=condition=Available deploy/mockdevice-opcua -n devices --timeout=150s
+              kubectl apply -f $(System.DefaultWorkingDirectory)/examples/deviceshifu/demo_device/edgedevice-opcua
+              kubectl wait --for=condition=Available deploy/deviceshifu-opcua-deployment -n deviceshifu --timeout=150s
+              kubectl wait --for=jsonpath='{status.edgedevicephase}'=Running edgedevice/edgedevice-opcua -n devices --timeout=150s
+              kubectl wait --for=condition=Ready pod/nginx -n deviceshifu --timeout=150s
+              bash $(System.DefaultWorkingDirectory)/examples/deviceshifu/mockdevice/opcua/checkout.sh
+              kubectl delete -f $(System.DefaultWorkingDirectory)/examples/deviceshifu/demo_device/edgedevice-opcua
+              kubectl delete -f $(System.DefaultWorkingDirectory)/examples/deviceshifu/demo_device/edgedevice-opcua/mock-device
+            displayName: "Shifu demo device OPCUA E2E test"
+
+      - job: kind_e2e_test_lwm2m
+        steps:
+          - task: GoTool@0
+            inputs:
+              version: $(goVersion)
+          - script: |
+              tag=`cat version.txt` && echo "##vso[task.setvariable variable=tag]$tag"
+            displayName: Set the tag name as an environment variable
+          - script: |
+              make buildx-build-image-shifu-controller
+            displayName: build edgehub/shifu-controller
+          - script: |
+              make buildx-build-image-deviceshifu-http-lwm2m
+            displayName: build edgehub/deviceshifu-http-lwm2m
+          - script: |
+              set -e
+              kind --version
+              kind delete cluster && kind create cluster
+              kind load docker-image edgehub/shifu-controller:$(tag)  
+              kind load docker-image edgehub/deviceshifu-http-lwm2m:$(tag)
+
+              kubectl version
+              kubectl apply -f $(System.DefaultWorkingDirectory)/pkg/k8s/crd/install/shifu_install.yml
+              kubectl wait --for=condition=Available deploy/shifu-crd-controller-manager -n shifu-crd-system --timeout=150s
+            displayName: "setup Kind cluster and install Shifu"
+          - script: |
+              set -e 
+              kubectl run nginx --image=nginx -n deviceshifu
+              kubectl apply -f $(System.DefaultWorkingDirectory)/examples/lwM2MDeviceShifuWithSecurity/lwM2M
+              kubectl wait --for=condition=Available deploy/deviceshifu-lwm2m-deployment -n deviceshifu --timeout=150s
+              kubectl wait --for=condition=Ready pod/nginx -n deviceshifu --timeout=150s
+              kubectl apply -f $(System.DefaultWorkingDirectory)/examples/lwM2MDeviceShifuWithSecurity/mockdevice
+              kubectl wait --for=condition=available --timeout=150s deployment/leshan-client -n deviceshifu
+              bash $(System.DefaultWorkingDirectory)/examples/deviceshifu/mockdevice/lwM2M/checkoutput.sh
+              kubectl delete -R -f $(System.DefaultWorkingDirectory)/examples/lwM2MDeviceShifuWithSecurity
+            displayName: "Shifu demo device lwM2M E2E test with security"
+          - script: |
+              set -e 
+              kubectl apply -f $(System.DefaultWorkingDirectory)/examples/lwM2MDeviceshifuWithoutSecurity/lwM2M
+              kubectl wait --for=condition=Available deploy/deviceshifu-lwm2m-deployment -n deviceshifu --timeout=150s
+              kubectl apply -f $(System.DefaultWorkingDirectory)/examples/lwM2MDeviceshifuWithoutSecurity/mockdevice
+              kubectl wait --for=condition=available --timeout=150s deployment/leshan-client -n deviceshifu
+              bash $(System.DefaultWorkingDirectory)/examples/deviceshifu/mockdevice/lwM2M/checkoutput.sh
+              kubectl delete -R -f $(System.DefaultWorkingDirectory)/examples/lwM2MDeviceshifuWithoutSecurity
+            displayName: "Shifu demo device lwM2M E2E test without security"
+
+      - job: kind_e2e_test_socket
+        steps:
+          - task: GoTool@0
+            inputs:
+              version: $(goVersion)
+          - script: |
+              tag=`cat version.txt` && echo "##vso[task.setvariable variable=tag]$tag"
+            displayName: Set the tag name as an environment variable
+          - script: |
+              make buildx-build-image-shifu-controller
+            displayName: build edgehub/shifu-controller
+          - script: |
+              make buildx-build-image-deviceshifu-http-socket
+            displayName: build edgehub/deviceshifu-http-socket
+          - script: |
+              make buildx-build-image-mockdevice-socket
+            displayName: build mockdevice-socket
+          - script: |
+              set -e
+              kind --version
+              kind delete cluster && kind create cluster
+              kind load docker-image edgehub/shifu-controller:$(tag)
+              kind load docker-image edgehub/deviceshifu-http-socket:$(tag)
+              kind load docker-image edgehub/mockdevice-socket:$(tag)
+
+              kubectl version
+              kubectl apply -f $(System.DefaultWorkingDirectory)/pkg/k8s/crd/install/shifu_install.yml
+              kubectl wait --for=condition=Available deploy/shifu-crd-controller-manager -n shifu-crd-system --timeout=150s
+            displayName: "setup Kind cluster and install Shifu"
+          - script: |
+              set -e 
+              kubectl run nginx --image=nginx -n deviceshifu
+              kubectl apply -f $(System.DefaultWorkingDirectory)/examples/deviceshifu/demo_device/edgedevice-socket/mock-device
+              kubectl wait --for=condition=Available deploy/mockdevice-socket -n devices --timeout=150s
+              kubectl apply -f $(System.DefaultWorkingDirectory)/examples/deviceshifu/demo_device/edgedevice-socket
+              kubectl wait --for=condition=Available deploy/deviceshifu-socket-deployment -n deviceshifu --timeout=150s
+              kubectl wait --for=jsonpath='{status.edgedevicephase}'=Running edgedevice/edgedevice-socket -n devices --timeout=150s
+              kubectl wait --for=condition=Ready pod/nginx -n deviceshifu --timeout=150s
+              bash $(System.DefaultWorkingDirectory)/examples/deviceshifu/mockdevice/socket/checkout.sh
+              kubectl delete -f $(System.DefaultWorkingDirectory)/examples/deviceshifu/demo_device/edgedevice-socket
+              kubectl delete -f $(System.DefaultWorkingDirectory)/examples/deviceshifu/demo_device/edgedevice-socket/mock-device
+            displayName: "Shifu demo device Socket E2E test"
+
+      - job: kind_e2e_test_gateway_lwm2m_http
+        steps:
+          - task: GoTool@0
+            inputs:
+              version: $(goVersion)
+          - script: |
+              tag=`cat version.txt` && echo "##vso[task.setvariable variable=tag]$tag"
+            displayName: Set the tag name as an environment variable
+          - script: |
+              make buildx-build-image-mockdevice-thermometer
+            displayName: build edgehub/mockdevice-thermometer
+          - script: |
+              make buildx-build-image-shifu-controller
+            displayName: build edgehub/shifu-controller
+          - script: |
+              make buildx-build-image-deviceshifu-http-http
+            displayName: build edgehub/deviceshifu-http-http
+          - script: |
+              make buildx-build-image-deviceshifu-http-lwm2m
+            displayName: build edgehub/deviceshifu-http-lwm2m
+          - script: |
+              make buildx-build-image-gateway-lwm2m
+            displayName: build edgehub/gateway-lwm2m
+          - script: |
+              set -e
+              kind --version
+              kind delete cluster && kind create cluster
+              kind load docker-image edgehub/mockdevice-thermometer:$(tag)
+              kind load docker-image edgehub/shifu-controller:$(tag)  
+              kind load docker-image edgehub/deviceshifu-http-http:$(tag)
+              kind load docker-image edgehub/gateway-lwm2m:$(tag)
+              kind load docker-image edgehub/deviceshifu-http-lwm2m:$(tag)
+
+              kubectl version
+              kubectl apply -f $(System.DefaultWorkingDirectory)/pkg/k8s/crd/install/shifu_install.yml
+              kubectl wait --for=condition=Available deploy/shifu-crd-controller-manager -n shifu-crd-system --timeout=150s
+            displayName: "setup Kind cluster and install Shifu"
+          - script: |
+              set -e 
+              kubectl run nginx --image=nginx -n deviceshifu
+              kubectl apply -f $(System.DefaultWorkingDirectory)/examples/lwm2m_gw_http/deviceshifu-lwm2m
+              kubectl wait --for=condition=available --timeout=150s deployment/deviceshifu-lwm2m-deployment -n deviceshifu --timeout=150s
+              kubectl wait --for=condition=Ready pod/nginx -n deviceshifu --timeout=150s
+              kubectl apply -f $(System.DefaultWorkingDirectory)/examples/lwm2m_gw_http/deviceshifu-thermometer
+              kubectl wait --for=condition=Available deployment/deviceshifu-thermometer-deployment -n deviceshifu --timeout=150s
+              bash $(System.DefaultWorkingDirectory)/examples/lwm2m_gw_http/checkoutput.sh
+              kubectl delete -R -f $(System.DefaultWorkingDirectory)/examples/lwm2m_gw_http
+            displayName: "Shifu demo device lwM2M http E2E test"
+
+      - job: kind_e2e_test_mqtt
+        steps:
+          - task: GoTool@0
+            inputs:
+              version: $(goVersion)
+          - script: |
+              tag=`cat version.txt` && echo "##vso[task.setvariable variable=tag]$tag"
+            displayName: Set the tag name as an environment variable
+          - script: |
+              make buildx-build-image-shifu-controller
+            displayName: build edgehub/shifu-controller
+          - script: |
+              make buildx-build-image-deviceshifu-http-mqtt
+            displayName: build edgehub/deviceshifu-http-mqtt
+          - script: |
+              set -e
+              kind --version
+              kind delete cluster && kind create cluster
+              kind load docker-image edgehub/shifu-controller:$(tag)  
+              kind load docker-image edgehub/deviceshifu-http-mqtt:$(tag)
+
+              kubectl version
+              kubectl apply -f $(System.DefaultWorkingDirectory)/pkg/k8s/crd/install/shifu_install.yml
+              kubectl wait --for=condition=Available deploy/shifu-crd-controller-manager -n shifu-crd-system --timeout=150s
+            displayName: "setup Kind cluster and install Shifu"
+          - script: |
+              set -e 
+              kubectl run nginx --image=nginx -n deviceshifu
+              kubectl apply -f $(System.DefaultWorkingDirectory)/examples/deviceshifu/demo_device/edgedevice-mqtt
+              kubectl wait --for=condition=Available deploy/mosquitto -n devices --timeout=150s
+              kubectl wait --for=condition=Available deploy/deviceshifu-mqtt-deployment -n deviceshifu --timeout=150s
+              kubectl run mosquitto -n devices --image=eclipse-mosquitto:2.0.14
+              kubectl wait --for=condition=Ready pod/mosquitto -n devices --timeout=150s
+              kubectl wait --for=condition=Ready pod/nginx -n deviceshifu --timeout=150s
+              bash $(System.DefaultWorkingDirectory)/examples/deviceshifu/mockdevice/mqtt/checkoutput.sh
+              kubectl delete -f examples/deviceshifu/demo_device/edgedevice-mqtt
+              kubectl delete po mosquitto -n devices
+            displayName: "Shifu demo device MQTT E2E test"
+
+      - job: kind_e2e_test_customized
+        steps:
+          - task: GoTool@0
+            inputs:
+              version: $(goVersion)
+          - script: |
+              tag=`cat version.txt` && echo "##vso[task.setvariable variable=tag]$tag"
+            displayName: Set the tag name as an environment variable
+          - script: |
+              make buildx-build-image-shifu-controller
+            displayName: build edgehub/shifu-controller
+          - script: |
+              docker buildx build --platform=linux/amd64 \
+              -f $(System.DefaultWorkingDirectory)/examples/deviceshifu/customized/humidity_detector/Dockerfile \
+              --build-arg PROJECT_ROOT="$(System.DefaultWorkingDirectory)" $(System.DefaultWorkingDirectory)/examples/deviceshifu/customized/humidity_detector \
+              -t edgehub/humidity-detector:$(tag) --load
+            displayName: build edgehub/humidity-detector
+          - script: |
+              docker buildx build --platform=linux/amd64 \
+              -f $(System.DefaultWorkingDirectory)/examples/deviceshifu/customized/humidity_detector/sample_deviceshifu_dockerfiles/Dockerfile.deviceshifuHTTP-Python \
+              --build-arg PROJECT_ROOT="$(System.DefaultWorkingDirectory)" $(System.DefaultWorkingDirectory) \
+              -t edgehub/deviceshifu-http-http-python:$(tag) --load
+            displayName: build edgehub/deviceshifu-http-http-python
+          - script: |
+              docker buildx build --platform=linux/amd64 \
+              -f $(System.DefaultWorkingDirectory)/examples/deviceshifu/customized/humidity_detector/mockserver/Dockerfile \
+              --build-arg PROJECT_ROOT="$(System.DefaultWorkingDirectory)" $(System.DefaultWorkingDirectory)/examples/deviceshifu/customized/humidity_detector/mockserver \
+              -t edgehub/mockserver:$(tag) --load
+            displayName: build edgehub/mockserver
+          - script: |
+              set -e
+              kind --version
+              kind delete cluster && kind create cluster
+              kind load docker-image edgehub/shifu-controller:$(tag)
+              kind load docker-image edgehub/humidity-detector:$(tag)  
+              kind load docker-image edgehub/deviceshifu-http-http-python:$(tag)
+              kind load docker-image edgehub/mockserver:$(tag)
+
+              kubectl version
+              kubectl apply -f $(System.DefaultWorkingDirectory)/pkg/k8s/crd/install/shifu_install.yml
+              kubectl wait --for=condition=Available deploy/shifu-crd-controller-manager -n shifu-crd-system --timeout=150s
+            displayName: "setup Kind cluster and install Shifu"
+          - script: |
+              set -e 
+              kubectl run nginx --image=nginx -n deviceshifu
+              kubectl apply -f $(System.DefaultWorkingDirectory)/examples/deviceshifu/customized/humidity_detector/configuration
+              kubectl wait --for=condition=Available deploy/humidity-detector -n devices --timeout=150s
+              kubectl wait --for=condition=Available deploy/deviceshifu-humidity-detector-deployment -n deviceshifu --timeout=150s
+              kubectl wait --for=condition=Available deploy/mockserver -n devices --timeout=150s
+              kubectl wait --for=condition=Ready pod/nginx -n deviceshifu --timeout=150s
+              cd $(System.DefaultWorkingDirectory)/examples/deviceshifu/customized/humidity_detector && bash checkout.sh && cd -
+              kubectl delete -f $(System.DefaultWorkingDirectory)/examples/deviceshifu/customized/humidity_detector/configuration
+            displayName: "Shifu demo humidity_detector deviceshifu E2E test"
+
+      - job: build_test_plc4x
+        steps:
+          - task: GoTool@0
+            inputs:
+              version: $(goVersion)
+          - script: |
+              tag=`cat version.txt` && echo "##vso[task.setvariable variable=tag]$tag"
+            displayName: Set the tag name as an environment variable
+          - script: |
+              make buildx-build-image-deviceshifu-http-plc4x
+            displayName: build edgehub/deviceshifu-http-plc4x
+
+      - job: docker_e2e_test_telemetryservice
+        steps:
+          - task: GoTool@0
+            inputs:
+              version: $(goVersion)
+          - script: |
+              tag=`cat version.txt` && echo "##vso[task.setvariable variable=tag]$tag"
+            displayName: Set the tag name as an environment variable
+          - script: |
+              make buildx-build-image-telemetry-service
+              docker run -itd --network host -e SERVER_LISTEN_PORT=:17772 edgehub/telemetryservice:$(tag)
+            displayName: build edgehub/telemetryService
+          - script: |
+              docker buildx build --platform=linux/amd64 \
+                -f $(System.DefaultWorkingDirectory)/examples/telemetryservice/mockclient/Dockerfile.mockclient \
+                --build-arg PROJECT_ROOT="$(System.DefaultWorkingDirectory)" $(System.DefaultWorkingDirectory) \
+                -t edgehub/mockclient:$(tag) --load
+              docker run -itd --network host -e TARGET_SERVER_ADDRESS=:17772 \
+                -e TARGET_MQTT_SERVER_ADDRESS=localhost:1883 \
+                -e TARGET_TDENGINE_SERVER_ADDRESS=localhost:6041 \
+                -e TARGET_MYSQL_SERVER_ADDRESS=localhost:3306 \
+                -e TARGET_SQLSERVER_SERVER_ADDRESS=localhost:1433 \
+                --name mockclient edgehub/mockclient:$(tag)
+            displayName: build mockClient
+          - script: |
+              docker run -itd --network host --name nginx nginx:1.21
+            displayName: docker run nginx
+          - script: |
+              set -e
+              docker run -itd --network host --name sqlserver -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=YourStrong@Passw0rd" \
+                --health-cmd="/opt/mssql-tools18/bin/sqlcmd -U sa -C -P YourStrong@Passw0rd -Q 'select name from sys.databases'" --health-interval=5s --health-timeout=5s --health-retries=20 \
+                mcr.microsoft.com/mssql/server:2022-latest
+              bash $(System.DefaultWorkingDirectory)/examples/telemetryservice/sqlserver/checkoutput.sh
+              docker rm -f sqlserver
+            displayName: docker run sqlserver and checkoutput
+          - script: |
+              docker buildx build --platform=linux/amd64 \
+                -f $(System.DefaultWorkingDirectory)/examples/telemetryservice/mockserver/Dockerfile.mockserver \
+                --build-arg PROJECT_ROOT="$(System.DefaultWorkingDirectory)" $(System.DefaultWorkingDirectory) \
+                -t edgehub/mockserver:$(tag) --load
+            displayName: build mockServer
+          - script: |
+              set -e
+              docker run -itd --network host --name mosquitto eclipse-mosquitto:2.0.15
+              docker run -itd --network host --name mockserver edgehub/mockserver:$(tag)
+              bash $(System.DefaultWorkingDirectory)/examples/telemetryservice/mqtt/checkoutput.sh
+              docker rm -f mosquitto mockserver
+            displayName: e2e_test_mqtt and checkoutput
+          - script: |
+              set -e
+              docker run -itd --network host --name mosquitto \
+              -v $(System.DefaultWorkingDirectory)/examples/telemetryservice/mqtt/mosquitto.conf:/mosquitto/config/mosquitto.conf \
+              -v $(System.DefaultWorkingDirectory)/examples/telemetryservice/mqtt/mosquitto.password:/mosquitto/config/passwd_file \
+              eclipse-mosquitto:2.0.15
+              docker run -itd --network host --name mockserver \
+              -e MQTT_USERNAME=mosquitto \
+              -e MQTT_PASSWORD=mosquitto \
+              edgehub/mockserver:$(tag)
+              bash $(System.DefaultWorkingDirectory)/examples/telemetryservice/mqtt/checkoutput_auth.sh
+              docker rm -f mosquitto mockserver
+            displayName: e2e_test_mqtt_with_auth and checkoutput
+          - script: |
+              set -e
+              docker run -itd --network host --name tdengine \
+                -v $(System.DefaultWorkingDirectory)/examples/telemetryservice/tdengine/init.sql:/root/init.sql \
+                tdengine/tdengine:3.0.1.4
+              bash $(System.DefaultWorkingDirectory)/examples/telemetryservice/tdengine/checkoutput.sh
+              docker rm -f tdengine
+            displayName: docker run tdengine and checkoutput
+          - script: |
+              set -e
+              docker run -itd --network host --name mysql -e MYSQL_ALLOW_EMPTY_PASSWORD=yes \
+                --health-cmd='mysqladmin ping -h localhost -uroot' --health-interval=5s --health-timeout=5s --health-retries=20 \
+                mysql:8.1.0
+              bash $(System.DefaultWorkingDirectory)/examples/telemetryservice/mysql/checkoutput.sh
+              docker rm -f mysql
+            displayName: docker run mysql and checkoutput
+
+  - stage: docker_build_muiltiarch_and_push
+    condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'), not(startsWith(variables['Build.SourceBranchName'],'release')))
+    variables:
+      - name: release_tag
+        ${{ if eq(variables['Build.SourceBranchName'], 'main')}}:
+          value: "nightly"
+        ${{ else }}:
+          value: $[replace(variables['build.sourcebranch'], 'refs/tags/', '')]
+    jobs:
+      - job: docker_push_deviceshifu_http_http
+        steps:
+          - task: GoTool@0
+            inputs:
+              version: $(goVersion)
+          - task: Docker@2
+            displayName: Login to DockerHub
+            inputs:
+              command: login
+              containerRegistry: dockerhub-connection
+          - script: |
               docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
               docker buildx create --use
-              echo 'Building macOS-targeted demo packages (simulating macOS environment)...'
-              # Create a wrapper script that simulates macOS environment
-              cat > build_macos_demo.sh << 'EOF'
-              #!/bin/bash
-              # Override uname to simulate macOS
-              function uname() {
-                if [ "$1" = "-s" ]; then
-                  echo "Darwin"
-                elif [ "$1" = "-m" ]; then
-                  echo "x86_64"
+            displayName: configure multi-arch and buildx
+          - script: |
+              make buildx-push-image-deviceshifu-http-http
+            displayName: build edgehub/deviceshifu-http-http
+
+      - job: docker_push_deviceshifu_http_socket
+        steps:
+          - task: GoTool@0
+            inputs:
+              version: $(goVersion)
+          - task: Docker@2
+            displayName: Login to DockerHub
+            inputs:
+              command: login
+              containerRegistry: dockerhub-connection
+          - script: |
+              docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+              docker buildx create --use
+            displayName: configure multi-arch and buildx
+          - script: |
+              make buildx-push-image-deviceshifu-http-socket
+            displayName: build edgehub/deviceshifu-http-socket
+
+      - job: docker_push_deviceshifu_http_mqtt
+        steps:
+          - task: GoTool@0
+            inputs:
+              version: $(goVersion)
+          - task: Docker@2
+            displayName: Login to DockerHub
+            inputs:
+              command: login
+              containerRegistry: dockerhub-connection
+          - script: |
+              docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+              docker buildx create --use
+            displayName: configure multi-arch and buildx
+          - script: |
+              make buildx-push-image-deviceshifu-http-mqtt
+            displayName: build edgehub/deviceshifu-http-mqtt
+
+      - job: docker_push_deviceshifu_http_opcua
+        steps:
+          - task: GoTool@0
+            inputs:
+              version: $(goVersion)
+          - task: Docker@2
+            displayName: Login to DockerHub
+            inputs:
+              command: login
+              containerRegistry: dockerhub-connection
+          - script: |
+              docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+              docker buildx create --use
+            displayName: configure multi-arch and buildx
+          - script: |
+              make buildx-push-image-deviceshifu-http-opcua
+            displayName: build deviceshifu-http-opcua
+
+      - job: docker_push_deviceshifu_http_lwm2m
+        steps:
+          - task: GoTool@0
+            inputs:
+              version: $(goVersion)
+          - task: Docker@2
+            displayName: Login to DockerHub
+            inputs:
+              command: login
+              containerRegistry: dockerhub-connection
+          - script: |
+              docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+              docker buildx create --use
+            displayName: configure multi-arch and buildx
+          - script: |
+              make buildx-push-image-deviceshifu-http-lwm2m
+            displayName: build deviceshifu-http-lwm2m
+
+      - job: docker_push_gateway_lwm2m
+        steps:
+          - task: GoTool@0
+            inputs:
+              version: $(goVersion)
+          - task: Docker@2
+            displayName: Login to DockerHub
+            inputs:
+              command: login
+              containerRegistry: dockerhub-connection
+          - script: |
+              docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+              docker buildx create --use
+            displayName: configure multi-arch and buildx
+          - script: |
+              make buildx-push-image-gateway-lwm2m
+            displayName: build gateway-lwm2m
+
+      - job: docker_push_deviceshifu_http_plc4x
+        steps:
+          - task: GoTool@0
+            inputs:
+              version: $(goVersion)
+          - task: Docker@2
+            displayName: Login to DockerHub
+            inputs:
+              command: login
+              containerRegistry: dockerhub-connection
+          - script: |
+              docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+              docker buildx create --use
+            displayName: configure multi-arch and buildx
+          - script: |
+              make buildx-push-image-deviceshifu-http-plc4x
+            displayName: build deviceshifu-http-plc4x
+
+      - job: docker_push_deviceshifu_tcp_tcp
+        steps:
+          - task: GoTool@0
+            inputs:
+              version: $(goVersion)
+          - task: Docker@2
+            displayName: Login to DockerHub
+            inputs:
+              command: login
+              containerRegistry: dockerhub-connection
+          - script: |
+              docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+              docker buildx create --use
+            displayName: configure multi-arch and buildx
+          - script: |
+              make buildx-push-image-deviceshifu-tcp-tcp
+            displayName: build deviceshifu-tcp-tcp
+
+      - job: docker_push_shifu_controller
+        steps:
+          - task: GoTool@0
+            inputs:
+              version: $(goVersion)
+          - task: Docker@2
+            displayName: Login to DockerHub
+            inputs:
+              command: login
+              containerRegistry: dockerhub-connection
+          - script: |
+              docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+              docker buildx create --use
+            displayName: configure multi-arch and buildx
+          - script: |
+              make buildx-push-image-shifu-controller
+            displayName: build edgehub/shifu-controller
+
+      - job: docker_push_mockdevice_thermometer
+        steps:
+          - task: GoTool@0
+            inputs:
+              version: $(goVersion)
+          - task: Docker@2
+            displayName: Login to DockerHub
+            inputs:
+              command: login
+              containerRegistry: dockerhub-connection
+          - script: |
+              docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+              docker buildx create --use
+            displayName: configure multi-arch and buildx
+          - script: |
+              make buildx-push-image-mockdevice-thermometer
+            displayName: build edgehub/mockdevice-thermometer
+
+      - job: docker_push_mockdevice_robot_arm
+        steps:
+          - task: GoTool@0
+            inputs:
+              version: $(goVersion)
+          - task: Docker@2
+            displayName: Login to DockerHub
+            inputs:
+              command: login
+              containerRegistry: dockerhub-connection
+          - script: |
+              docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+              docker buildx create --use
+            displayName: configure multi-arch and buildx
+          - script: |
+              make buildx-push-image-mockdevice-robot-arm
+            displayName: build edgehub/mockdevice-robot-arm
+
+      - job: docker_push_mockdevice_plate_reader
+        steps:
+          - task: GoTool@0
+            inputs:
+              version: $(goVersion)
+          - task: Docker@2
+            displayName: Login to DockerHub
+            inputs:
+              command: login
+              containerRegistry: dockerhub-connection
+          - script: |
+              docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+              docker buildx create --use
+            displayName: configure multi-arch and buildx
+          - script: |
+              make buildx-push-image-mockdevice-plate-reader
+            displayName: build edgehub/mockdevice-plate-reader
+
+      - job: docker_push_mockdevice_agv
+        steps:
+          - task: GoTool@0
+            inputs:
+              version: $(goVersion)
+          - task: Docker@2
+            displayName: Login to DockerHub
+            inputs:
+              command: login
+              containerRegistry: dockerhub-connection
+          - script: |
+              docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+              docker buildx create --use
+            displayName: configure multi-arch and buildx
+          - script: |
+              make buildx-push-image-mockdevice-agv
+            displayName: build edgehub/mockdevice-agv
+
+      - job: docker_push_mockdevice_plc
+        steps:
+          - task: GoTool@0
+            inputs:
+              version: $(goVersion)
+          - task: Docker@2
+            displayName: Login to DockerHub
+            inputs:
+              command: login
+              containerRegistry: dockerhub-connection
+          - script: |
+              docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+              docker buildx create --use
+            displayName: configure multi-arch and buildx
+          - script: |
+              make buildx-push-image-mockdevice-plc
+            displayName: build edgehub/mockdevice-plc
+
+      - job: docker_push_mockdevice_socket
+        steps:
+          - task: GoTool@0
+            inputs:
+              version: $(goVersion)
+          - task: Docker@2
+            displayName: Login to DockerHub
+            inputs:
+              command: login
+              containerRegistry: dockerhub-connection
+          - script: |
+              docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+              docker buildx create --use
+            displayName: configure multi-arch and buildx
+          - script: |
+              make buildx-push-image-mockdevice-socket
+            displayName: build edgehub/mockdevice-socket
+
+      - job: docker_push_mockdevice_opcua
+        steps:
+          - task: GoTool@0
+            inputs:
+              version: $(goVersion)
+          - task: Docker@2
+            displayName: Login to DockerHub
+            inputs:
+              command: login
+              containerRegistry: dockerhub-connection
+          - script: |
+              docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+              docker buildx create --use
+            displayName: configure multi-arch and buildx
+          - script: |
+              make buildx-push-image-mockdevice-opcua
+            displayName: build edgehub/mockdevice-opcua
+
+      - job: docker_push_telemetry_service
+        steps:
+          - task: GoTool@0
+            inputs:
+              version: $(goVersion)
+          - task: Docker@2
+            displayName: Login to DockerHub
+            inputs:
+              command: login
+              containerRegistry: dockerhub-connection
+          - script: |
+              docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+              docker buildx create --use
+            displayName: configure multi-arch and buildx
+          - script: |
+              make buildx-push-image-telemetry-service
+            displayName: push edgehub/telemetryservice
+
+  - stage: docker_build_shifu_demo_push
+    condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/macos-docker-smoke'), ne(variables['Build.Reason'], 'PullRequest'), contains(variables['Build.SourceBranch'],'refs/tags'), not(contains(variables['Build.SourceBranchName'],'rc')))
+    jobs:
+      - job: docker_push_shifu_demo
+        steps:
+          - script: |
+              set -e
+              bash test/scripts/deviceshifu-demo-aio.sh build_demo amd64
+              bash test/scripts/deviceshifu-demo-aio.sh build_demo arm64
+              ls -al
+            displayName: "Run the build script"
+          - script: |
+              set -e
+              mkdir testdir && tar -xvf shifu_demo_aio_linux_amd64.tar -C testdir && cd testdir
+              chmod +x test/scripts/deviceshifu-demo-aio.sh && sudo ./test/scripts/deviceshifu-demo-aio.sh run_demo
+            displayName: "test run_demo"
+          - script: |
+              set -e
+              sudo kubectl run nginx --image=nginx:1.21 -n deviceshifu
+              sudo kubectl wait --for=condition=Available deploy/shifu-crd-controller-manager -n shifu-crd-system --timeout=150s
+              sudo kubectl wait --for=condition=Available deploy/deviceshifu-agv-deployment -n deviceshifu --timeout=150s
+              sudo kubectl wait --for=condition=Available deploy/agv -n devices --timeout=150s
+              sudo kubectl wait --for=condition=Ready pod/nginx -n deviceshifu --timeout=150s
+              sudo kubectl exec -it -n deviceshifu nginx -- curl http://deviceshifu-agv/get_position
+            displayName: "test run_demo result"
+          - task: CopyFilesOverSSH@0
+            condition: succeeded()
+            inputs:
+              sshEndpoint: "shifurun-ssh"
+              contents: |
+                shifu_demo_aio_linux_amd64.tar
+                shifu_demo_aio_linux_arm64.tar
+              targetFolder: "/home/ubuntu/demo-files"
+              readyTimeout: "20000"
+              failOnEmptySource: true
+          - task: SSH@0
+            condition: succeeded()
+            inputs:
+              sshEndpoint: "shifurun-ssh"
+              runOptions: "inline"
+              inline: "sudo cp -R /home/ubuntu/demo-files/* /var/www/demo-site/demo-content"
+              readyTimeout: "20000"
+
+          - task: CopyFilesOverSSH@0
+            condition: succeeded()
+            displayName: push demo file to shifu.dev
+            inputs:
+              sshEndpoint: "shifu.dev"
+              contents: |
+                shifu_demo_aio_linux_amd64.tar
+                shifu_demo_aio_linux_arm64.tar
+              targetFolder: "/home/ubuntu/demo-files"
+              readyTimeout: "20000"
+              failOnEmptySource: true
+          - task: SSH@0
+            condition: succeeded()
+            inputs:
+              sshEndpoint: "shifu.dev"
+              runOptions: "inline"
+              inline: "sudo cp -R /home/ubuntu/demo-files/* /var/www/demo-site/demo-content"
+              readyTimeout: "20000"
+
+      - job: docker_push_shifu_demo_mac
+        pool:
+          vmImage: "macOS-latest"
+        steps:
+          - script: |
+              brew --version
+              brew update
+              brew --version
+              brew install --cask --no-quarantine docker
+              echo 'Installing Docker Desktop for Mac ...'
+              start=$SECONDS
+              sudo /Applications/Docker.app/Contents/MacOS/Docker --unattended --install-privileged-components
+              open -a /Applications/Docker.app --args --unattended --accept-license
+              end=$SECONDS
+              duration=$(( end - start ))
+              echo "Docker Desktop for Mac has been installed in $duration seconds"
+              echo 'Starting Docker service ...'
+              start=$SECONDS
+              retries=0
+              maxRetries=100
+              sudo bash -c `
+              set -x
+              command -v docker || echo 'test docker command 1: not found'
+              i=0
+              while ! /Applications/Docker.app/Contents/Resources/bin/docker system info &>/dev/null; do
+              (( i++ == 0 )) && printf %s '-- Waiting for Docker to finish starting up...' || printf '.'
+              command -v docker || echo 'test docker command loop: not found'
+              sleep 5
+              if [ $i -gt 180 ];then sudo /Applications/Docker.app/Contents/MacOS/com.docker.diagnose check;uname -a;system_profiler SPHardwareDataType;echo "::error::-- Wait docker start $i s too long, exit"; exit 1; fi
+              done
+              echo "::notice::-- Docker is ready.Wait time is $i s"
+              uname -a || true
+              system_profiler SPHardwareDataType || true
+              `
+              end=$SECONDS
+              duration=$(( end - start ))
+              echo "Docker service has started after $duration seconds"
+              docker --version
+              docker-compose --version
+            displayName: Install and start Docker
+          - script: |
+              set -e
+              bash ./test/scripts/deviceshifu-demo-aio.sh build_demo amd64
+              bash ./test/scripts/deviceshifu-demo-aio.sh build_demo arm64
+              ls -al
+            displayName: "Run the build script"
+          - script: |
+              set -e
+              mkdir testdir && tar -xvf shifu_demo_aio_darwin_amd64.tar -C testdir && cd testdir
+              chmod +x ./test/scripts/deviceshifu-demo-aio.sh && sudo ./test/scripts/deviceshifu-demo-aio.sh run_demo
+            displayName: "test run_demo"
+          - script: |
+              set -e
+              sudo kubectl wait --for=condition=Available deploy/shifu-crd-controller-manager -n shifu-crd-system --timeout=150s
+              sudo kubectl wait --for=condition=Available deploy/deviceshifu-agv-deployment -n deviceshifu --timeout=150s
+              sudo kubectl wait --for=condition=Available deploy/agv -n devices --timeout=150s
+              sudo kubectl run nginx --image=nginx:1.21 -n deviceshifu
+              sudo kubectl wait --for=condition=Ready pod/nginx -n deviceshifu --timeout=150s
+              sudo kubectl exec -it -n deviceshifu nginx -- curl http://deviceshifu-agv/get_position
+            displayName: "test run_demo result"
+          - task: CopyFilesOverSSH@0
+            condition: succeeded()
+            inputs:
+              sshEndpoint: "shifurun-ssh"
+              contents: |
+                shifu_demo_aio_darwin_amd64.tar
+                shifu_demo_aio_darwin_arm64.tar
+              targetFolder: "/home/ubuntu/demo-files"
+              readyTimeout: "20000"
+              failOnEmptySource: true
+          - task: SSH@0
+            condition: succeeded()
+            inputs:
+              sshEndpoint: "shifurun-ssh"
+              runOptions: "inline"
+              inline: "sudo cp -R /home/ubuntu/demo-files/* /var/www/demo-site/demo-content"
+              readyTimeout: "20000"
+
+          - task: CopyFilesOverSSH@0
+            condition: succeeded()
+            displayName: push demo file to shifu.dev mac
+            inputs:
+              sshEndpoint: "shifu.dev"
+              contents: |
+                shifu_demo_aio_darwin_amd64.tar
+                shifu_demo_aio_darwin_arm64.tar
+              targetFolder: "/home/ubuntu/demo-files"
+              readyTimeout: "20000"
+              failOnEmptySource: true
+          - task: SSH@0
+            condition: succeeded()
+            inputs:
+              sshEndpoint: "shifu.dev"
+              runOptions: "inline"
+              inline: "sudo cp -R /home/ubuntu/demo-files/* /var/www/demo-site/demo-content"
+              readyTimeout: "20000"
+
+  - stage: macos_docker_smoke
+    displayName: macOS Docker smoke
+    condition: eq(variables['Build.SourceBranch'], 'refs/heads/macos-docker-smoke')
+    jobs:
+      - job: macos_docker_smoke
+        displayName: macOS Docker smoke
+        pool:
+          vmImage: "macOS-latest"
+        steps:
+          - script: |
+              set -euo pipefail
+              DOCKER_CLI="/Applications/Docker.app/Contents/Resources/bin/docker"
+              brew --version
+              brew update
+              brew --version
+              brew install --cask --no-quarantine docker
+              echo 'Installing Docker Desktop for Mac ...'
+              start=$SECONDS
+              sudo /Applications/Docker.app/Contents/MacOS/Docker --unattended --install-privileged-components
+              open -a /Applications/Docker.app --args --unattended --accept-license
+              i=0
+              while ! "$DOCKER_CLI" system info &>/dev/null; do
+                if [ $i -eq 0 ]; then
+                  printf '%s' '-- Waiting for Docker to finish starting up...'
                 else
-                  command uname "$@"
+                  printf '.'
                 fi
-              }
-              export -f uname
-              # Run the original script with architecture parameter
-              bash test/scripts/deviceshifu-demo-aio.sh build_demo "$1"
-              EOF
-              chmod +x build_macos_demo.sh
-              echo 'Building for amd64...'
-              ./build_macos_demo.sh amd64
-              echo 'Building for arm64...'
-              ./build_macos_demo.sh arm64
-              echo 'Checking built artifacts:'
-              ls -la shifu_demo_aio_darwin_*.tar || ls -la *.tar || echo "No tar files found"
-              echo 'Extracting and testing demo structure:'
-              if [ -f shifu_demo_aio_darwin_amd64.tar ]; then
-                mkdir -p test_extract
-                echo 'Contents of darwin amd64 tar:'
-                tar -tf shifu_demo_aio_darwin_amd64.tar | head -20
-                tar -xf shifu_demo_aio_darwin_amd64.tar -C test_extract
-                echo 'Demo structure:'
-                find test_extract -name "*.sh" -o -name "shifu*" | head -10
-                echo '✅ macOS demo build smoke test PASSED'
-              else
-                echo '❌ macOS demo tar file not found - showing what we got:'
-                ls -la *.tar || echo "No tar files at all"
-                exit 1
-              fi
-            displayName: Build and verify macOS demo packages
+                sleep 5
+                i=$((i + 1))
+                if [ $i -gt 180 ]; then
+                  echo '\n::error::Docker did not start within expected time';
+                  sudo /Applications/Docker.app/Contents/MacOS/com.docker.diagnose check || true
+                  exit 1
+                fi
+              done
+              end=$SECONDS
+              duration=$(( end - start ))
+              printf '\nDocker Desktop started after %s seconds\n' "$duration"
+              "$DOCKER_CLI" --version
+              "$DOCKER_CLI" run --rm hello-world
+            displayName: Install Docker Desktop and run hello-world

--- a/test/scripts/deviceshifu-demo-aio.sh
+++ b/test/scripts/deviceshifu-demo-aio.sh
@@ -3,7 +3,10 @@
 set -e
 
 if [ $# -eq 0 ]; then
-    echo "No arguments provided, use 'run_demo', 'build_demo' or 'delete_demo'"
+    echo "Usage: $0 <action> [arch] [os]"
+    echo "  action: 'run_demo', 'build_demo' or 'delete_demo'"
+    echo "  arch: 'amd64' or 'arm64' (optional, defaults to system arch)"
+    echo "  os: 'linux' or 'darwin' (optional, defaults to system os)"
     exit 1
 fi
 
@@ -42,9 +45,10 @@ UTIL_IMG_LIST=(
     'eclipse-mosquitto:2.0.14'
 )
 
+# Determine architecture
 arch=$(uname -m)
 build_arch=""
-if [[ ($# -eq 2 && ($2 == "amd64" || $2 == "arm64")) ]]; then
+if [[ ($# -ge 2 && ($2 == "amd64" || $2 == "arm64")) ]]; then
     build_arch=$2
 elif [[ $arch == x86_64* ]]; then
     build_arch="amd64"
@@ -55,14 +59,31 @@ else
     exit 1
 fi
 
+# Determine OS
 os=$(uname -s)
 build_os=""
-if [[ $os == Linux* ]]; then
+if [[ ($# -ge 3 && ($3 == "linux" || $3 == "darwin")) ]]; then
+    build_os=$3
+elif [[ $os == Linux* ]]; then
     build_os="linux"
-elif  [[ $os == Darwin* ]]; then
+elif [[ $os == Darwin* ]]; then
     build_os="darwin"
 else
-    echo "No support for CPU arch: $os, exiting..."
+    echo "No support for OS: $os, exiting..."
+    exit 1
+fi
+
+# Validate supported combinations
+if [[ $build_os == "darwin" && $build_arch == "amd64" ]]; then
+    echo "Warning: Darwin amd64 support is limited, arm64 is recommended for macOS"
+fi
+
+# Supported combinations: linux/amd64, linux/arm64, darwin/arm64
+supported_combinations=("linux/amd64" "linux/arm64" "darwin/arm64" "darwin/amd64")
+current_combo="$build_os/$build_arch"
+if [[ ! " ${supported_combinations[@]} " =~ " ${current_combo} " ]]; then
+    echo "Unsupported combination: $current_combo"
+    echo "Supported combinations: ${supported_combinations[*]}"
     exit 1
 fi
 


### PR DESCRIPTION
**What this PR does / why we need it**:
- Homebrew cask `docker.rb` disappeared, so install Docker Desktop via `brew install --cask docker`.
- Add a macOS-only smoke stage that installs Docker Desktop and runs `docker run --rm hello-world` to verify the new cask.
- Skip the heavy Linux/Windows/kind and release stages when the smoke branch runs so only the macOS validation executes.

**Will this PR make the community happier**? 
Yes — it keeps the release pipeline green while giving a safe macOS validation path.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**How is this PR tested**
- [ ] unit test
- [ ] e2e test
- [x] other (macOS smoke stage installs Docker Desktop and runs `docker run --rm hello-world`)

**Special notes for your reviewer**:
- Branch `macos-docker-smoke` is intended as a temporary validation branch.

**Release note**:
```release-note
NONE
```
