### PR TITLE
docs: deprecate PLC4X in v0.80 changelog

### DIFF
--- a/CHANGELOG/CHANGELOG-v0.80.0-zh.md
+++ b/CHANGELOG/CHANGELOG-v0.80.0-zh.md
@@ -1,0 +1,23 @@
+# 自 [v0.79.0](https://github.com/Edgenesis/shifu/releases/tag/v0.79.0) 以来的变更
+
+## 功能增强 ⚡
+
+- 用 Linux 交叉编译替换 macOS 构建器以支持 macOS ARM64，提升构建效率和兼容性
+
+## Bug 修复 🐛
+
+- 修复 lint 问题：将已弃用的 result.Requeue 替换为 RequeueAfter，确保代码库兼容最新标准
+
+## Dependabot 自动更新 🤖
+
+- Bump github.com/onsi/ginkgo/v2 from 2.25.1 to 2.25.3 by @dependabot[bot] in https://github.com/Edgenesis/shifu/pull/1267
+
+- Bump github.com/spf13/cobra from 1.9.1 to 1.10.1 by @dependabot[bot] in https://github.com/Edgenesis/shifu/pull/1266
+
+- Bump k8s.io/api from 0.33.4 to 0.34.1 by @dependabot[bot] in https://github.com/Edgenesis/shifu/pull/1268
+
+## 注意⚠️
+
+- [问题 #1271](https://github.com/Edgenesis/shifu/issues/1271) 自 v0.80.0 起将 PLC4X DeviceShifu 支持标记为弃用，并计划在 v0.81.0 正式移除
+
+**完整变更日志**: https://github.com/Edgenesis/shifu/compare/v0.79.0...v0.80.0

--- a/CHANGELOG/CHANGELOG-v0.80.0.md
+++ b/CHANGELOG/CHANGELOG-v0.80.0.md
@@ -1,0 +1,23 @@
+# Changelog since [v0.79.0](https://github.com/Edgenesis/shifu/releases/tag/v0.79.0)
+
+## Enhancements ⚡
+
+- Replace macOS builders with Linux cross-compilation for macOS ARM64 to improve build efficiency and compatibility
+
+## Bug Fixes 🐛
+
+- Fix lint issue by replacing deprecated result.Requeue with RequeueAfter to ensure codebase compatibility with latest standards
+
+## Dependabot Updates 🤖
+
+- Bump github.com/onsi/ginkgo/v2 from 2.25.1 to 2.25.3 by @dependabot[bot] in https://github.com/Edgenesis/shifu/pull/1267
+
+- Bump github.com/spf13/cobra from 1.9.1 to 1.10.1 by @dependabot[bot] in https://github.com/Edgenesis/shifu/pull/1266
+
+- Bump k8s.io/api from 0.33.4 to 0.34.1 by @dependabot[bot] in https://github.com/Edgenesis/shifu/pull/1268
+
+## NOTE⚠️
+
+- [Issue #1271](https://github.com/Edgenesis/shifu/issues/1271) Mark PLC4X DeviceShifu support as deprecated starting in v0.80.0, with official removal planned for v0.81.0
+
+**Full Changelog**: https://github.com/Edgenesis/shifu/compare/v0.79.0...v0.80.0


### PR DESCRIPTION
**What this PR does / why we need it**:
- Mark PLC4X DeviceShifu support as deprecated in the v0.80.0 changelog so operators can prepare for its removal in v0.81.0.

**Will this PR make the community happier**? 
Yes, it clarifies PLC4X status and communicates the removal timeline.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: refs #1271

**How is this PR tested**
- [ ] unit test
- [ ] e2e test
- [x] other (docs-only change)

**Special notes for your reviewer**:
- Targeting `release_v0.80.0`; no code changes beyond changelog text updates.

**Release note**:
```release-note
Mark PLC4X DeviceShifu as deprecated in the v0.80.0 changelog ahead of its planned removal in v0.81.0.
```
