### PR TITLE
Use bitnamilegacy kube-rbac-proxy image (release_v0.73.0)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -256,7 +256,7 @@ download-demo-files:
 	docker pull edgehub/mockdevice-thermometer:${IMAGE_VERSION}
 	docker pull edgehub/deviceshifu-http-http:${IMAGE_VERSION}
 	docker pull edgehub/shifu-controller:${IMAGE_VERSION}
-	docker pull bitnami/kube-rbac-proxy:0.14.1
+	docker pull bitnamilegacy/kube-rbac-proxy:0.14.1
 	docker pull nginx:1.21
 
 docker-push-image-deviceshifu:

--- a/pkg/k8s/crd/config/default/manager_auth_proxy_patch.yaml
+++ b/pkg/k8s/crd/config/default/manager_auth_proxy_patch.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: bitnami/kube-rbac-proxy:0.14.1
+        image: bitnamilegacy/kube-rbac-proxy:0.14.1
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/pkg/k8s/crd/install/config_default.yaml
+++ b/pkg/k8s/crd/install/config_default.yaml
@@ -593,7 +593,7 @@ spec:
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
         - --v=10
-        image: bitnami/kube-rbac-proxy:0.14.1
+        image: bitnamilegacy/kube-rbac-proxy:0.14.1
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443

--- a/pkg/k8s/crd/install/shifu_install.yml
+++ b/pkg/k8s/crd/install/shifu_install.yml
@@ -593,7 +593,7 @@ spec:
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
         - --v=10
-        image: bitnami/kube-rbac-proxy:0.14.1
+        image: bitnamilegacy/kube-rbac-proxy:0.14.1
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443

--- a/test/scripts/deviceshifu-demo-aio.sh
+++ b/test/scripts/deviceshifu-demo-aio.sh
@@ -36,7 +36,7 @@ KIND_IMG="kindest/node:v1.31.0"
 KIND_VERSION="v0.24.0"
 
 UTIL_IMG_LIST=(
-    'bitnami/kube-rbac-proxy:0.14.1'
+    'bitnamilegacy/kube-rbac-proxy:0.14.1'
     $KIND_IMG
     'nginx:1.21'
     'eclipse-mosquitto:2.0.14'

--- a/test/scripts/deviceshifu-setup.sh
+++ b/test/scripts/deviceshifu-setup.sh
@@ -13,7 +13,7 @@ if [ "$1" == "apply" ] || [ "$1" == "delete" ]; then
                 make download-demo-files
                 kind delete cluster && kind create cluster --image=kindest/node:v1.24.0
                 kind load docker-image nginx:1.21
-                kind load docker-image bitnami/kube-rbac-proxy:0.14.1
+                kind load docker-image bitnamilegacy/kube-rbac-proxy:0.14.1
                 kind load docker-image edgehub/deviceshifu-http-http:$TAG
                 kind load docker-image edgehub/shifu-controller:$TAG
                 kind load docker-image edgehub/mockdevice-agv:$TAG
@@ -26,7 +26,7 @@ if [ "$1" == "apply" ] || [ "$1" == "delete" ]; then
                 docker rmi $(docker images | grep 'edgehub/mockdevice' | awk '{print $3}')
                 docker rmi $(docker images | grep 'edgehub/deviceshifu-http-http' | awk '{print $3}')
                 docker rmi $(docker images | grep 'edgehub/shifu-controller' | awk '{print $3}')
-                docker rmi bitnami/kube-rbac-proxy:0.14.1
+                docker rmi bitnamilegacy/kube-rbac-proxy:0.14.1
                 docker rmi $(docker images | grep 'kindest/node' | awk '{print $3}')
                 docker rmi nginx:1.21
         fi


### PR DESCRIPTION
**What this PR does / why we need it**:
Switch release_v0.73.0 artifacts and helper scripts to pull `bitnamilegacy/kube-rbac-proxy:0.14.1` so clusters avoid the unavailable `bitnami` registry image.

**Will this PR make the community happier**? 
Yes

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #N/A

**How is this PR tested**
- [ ] unit test
- [ ] e2e test
- [x] other (please specify)
  - Not run; manifest-only image reference updates.

**Special notes for your reviewer**:
None

**Release note**:
```release-note
Use bitnamilegacy/kube-rbac-proxy:0.14.1 for release_v0.73.0 assets
```
