### PR TITLE
fix: Remove macOS demo test from CI pipeline

### DIFF
--- a/azure-pipelines/azure-pipelines.yml
+++ b/azure-pipelines/azure-pipelines.yml
@@ -895,20 +895,6 @@ stages:
               bash ./test/scripts/deviceshifu-demo-aio.sh build_demo arm64 darwin
               ls -al
             displayName: "Build macOS ARM64 demo"
-          - script: |
-              set -e
-              mkdir testdir && tar -xvf shifu_demo_aio_darwin_arm64.tar -C testdir && cd testdir
-              chmod +x ./test/scripts/deviceshifu-demo-aio.sh && sudo ./test/scripts/deviceshifu-demo-aio.sh run_demo
-            displayName: "test run_demo"
-          - script: |
-              set -e
-              sudo kubectl wait --for=condition=Available deploy/shifu-crd-controller-manager -n shifu-crd-system --timeout=150s
-              sudo kubectl wait --for=condition=Available deploy/deviceshifu-agv-deployment -n deviceshifu --timeout=150s
-              sudo kubectl wait --for=condition=Available deploy/agv -n devices --timeout=150s
-              sudo kubectl run nginx --image=nginx:1.21 -n deviceshifu
-              sudo kubectl wait --for=condition=Ready pod/nginx -n deviceshifu --timeout=150s
-              sudo kubectl exec -it -n deviceshifu nginx -- curl http://deviceshifu-agv/get_position
-            displayName: "test run_demo result"
           - task: CopyFilesOverSSH@0
             condition: succeeded()
             inputs:


### PR DESCRIPTION
## Summary
Remove failing macOS demo test from CI pipeline. The test was attempting to run darwin/arm64 binaries (kind/kubectl) on Linux CI runners, which is not possible.

## Changes
- Removed test steps from `docker_push_shifu_demo_mac` job in azure-pipelines.yml
- Kept the build step to continue producing darwin/arm64 archives for distribution
- Linux demo tests remain unchanged and continue to validate demo functionality

## Reasoning
The build process creates platform-specific archives containing:
- Docker images: always linux/$arch (work on Linux with qemu)
- Binaries (kind/kubectl): platform-specific (darwin binaries won't run on Linux)

Since the darwin archive contains darwin binaries, it cannot be tested on Linux CI runners. The Linux demo job already provides adequate test coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)