### PR TITLE
Switch CRD manager metrics service to HTTP

### DIFF
--- a/pkg/k8s/crd/config/edgedevice/bases/shifu.edgenesis.io_edgedevices.yaml
+++ b/pkg/k8s/crd/config/edgedevice/bases/shifu.edgenesis.io_edgedevices.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.16.3
   name: edgedevices.shifu.edgenesis.io
 spec:
   group: shifu.edgenesis.io

--- a/pkg/k8s/crd/config/edgedevice/bases/shifu.edgenesis.io_telemetryservices.yaml
+++ b/pkg/k8s/crd/config/edgedevice/bases/shifu.edgenesis.io_telemetryservices.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.16.3
   name: telemetryservices.shifu.edgenesis.io
 spec:
   group: shifu.edgenesis.io

--- a/pkg/k8s/crd/install/config_crd.yaml
+++ b/pkg/k8s/crd/install/config_crd.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.16.3
   name: edgedevices.shifu.edgenesis.io
 spec:
   group: shifu.edgenesis.io
@@ -228,7 +228,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.16.3
   name: telemetryservices.shifu.edgenesis.io
 spec:
   group: shifu.edgenesis.io

--- a/pkg/k8s/crd/install/config_default.yaml
+++ b/pkg/k8s/crd/install/config_default.yaml
@@ -9,7 +9,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.16.3
   name: edgedevices.shifu.edgenesis.io
 spec:
   group: shifu.edgenesis.io
@@ -235,7 +235,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.16.3
   name: telemetryservices.shifu.edgenesis.io
 spec:
   group: shifu.edgenesis.io

--- a/pkg/k8s/crd/install/shifu_install.yml
+++ b/pkg/k8s/crd/install/shifu_install.yml
@@ -9,7 +9,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.16.3
   name: edgedevices.shifu.edgenesis.io
 spec:
   group: shifu.edgenesis.io
@@ -235,7 +235,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.16.3
   name: telemetryservices.shifu.edgenesis.io
 spec:
   group: shifu.edgenesis.io
@@ -412,6 +412,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - services
   verbs:
   - create
@@ -561,10 +569,10 @@ metadata:
   namespace: shifu-crd-system
 spec:
   ports:
-  - name: https
-    port: 8443
+  - name: http
+    port: 8080
     protocol: TCP
-    targetPort: 8443
+    targetPort: 8080
   selector:
     app.kubernetes.io/name: crd
     control-plane: controller-manager
@@ -591,7 +599,8 @@ spec:
     spec:
       containers:
       - args:
-        - --metrics-bind-address=:8443
+        - --metrics-bind-address=:8080
+        - --metrics-secure=false
         - --leader-elect
         - --enable-user-metrics
         - --user-metrics-interval=60


### PR DESCRIPTION
**What this PR does / why we need it**:
- expose the CRD controller metrics endpoint over HTTP on port 8080 and disable TLS in the service/deployment
- align controller-gen annotations with v0.16.3 output and grant the manager pod list/watch permissions it now requires

**Will this PR make the community happier**?
- Yes, it keeps the CRD deployment working after removing the kube-rbac-proxy sidecar.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #N/A

**How is this PR tested**
- [ ] unit test
- [ ] e2e test
- [x] other (please specify)
  - Not run; manifests only.

**Special notes for your reviewer**:

**Release note**:
```release-note
Switch the CRD manager metrics service to HTTP on port 8080 and sync controller-gen metadata to v0.16.3.
```
