### PR TITLE
Fix test reliability with dynamic port allocation and graceful shutdown

### DIFF
--- a/pkg/deviceshifu/deviceshifutcp/deviceshifutcp_test.go
+++ b/pkg/deviceshifu/deviceshifutcp/deviceshifutcp_test.go
@@ -2,6 +2,7 @@ package deviceshifutcp
 
 import (
 	"encoding/json"
+	"errors"
 	"github.com/edgenesis/shifu/pkg/deviceshifu/deviceshifubase"
 	"github.com/edgenesis/shifu/pkg/deviceshifu/unitest"
 	"github.com/edgenesis/shifu/pkg/k8s/api/v1alpha1"
@@ -31,6 +32,9 @@ func TestMain(m *testing.M) {
 		for {
 			conn, err := listener.Accept()
 			if err != nil {
+				if errors.Is(err, net.ErrClosed) {
+					return
+				}
 				logger.Error(err)
 				continue
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR improves test reliability by fixing port conflicts and graceful shutdown issues in test suites:

- **Dynamic port allocation**: Replaces hardcoded port `localhost:18927` in telemetryservice tests with `getFreeLocalAddr()` helper that finds available ports, preventing conflicts when tests run in parallel or port is already in use
- **Proper test isolation**: Refactors tests to use `t.Run()` subtests with proper closure variable capture
- **Timing bug fix**: Fixes `TestNew()` which incorrectly used `time.After()` (returns channel) instead of `time.Sleep()`, causing immediate execution rather than delayed
- **Graceful shutdown**: Adds `net.ErrClosed` handling in deviceshifutcp tests to prevent spurious error logs when the test listener is intentionally closed

**Will this PR make the community happier**?

Yes! These changes make tests more reliable and eliminate flaky test failures due to port conflicts, which improves the developer experience for contributors.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**How is this PR tested**
- [x] unit test - Modified existing tests use the new patterns
- [ ] e2e test
- [ ] other (please specify)

**Special notes for your reviewer**:

The `getFreeLocalAddr()` helper has a small theoretical race condition (port could be taken between close and use), but this is a standard pattern in Go testing and acceptable for test scenarios.

**Release note**:
```release-note
Improve test reliability by using dynamic port allocation and fixing graceful shutdown in unit tests
```