### PR TITLE
chore: streamline release changelog workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,17 +1,7 @@
-name: Auto Generate Release Log
+name: Prepare Release Changelog
 
 on:
   workflow_dispatch:
-    inputs:
-      tag_name:
-        required: true
-        type: string
-      previous_tag_name:
-        required: true
-        type: string
-      target_commitish:
-        required: true
-        type: string
 
 permissions:
   contents: write
@@ -22,33 +12,76 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.24.2"
-      - name: set version
+          go-version-file: go.mod
+
+      - name: Determine next release version
+        id: version
+        shell: bash
         run: |
-          echo "VERSION=$(echo "${{inputs.tag_name}}" | cut -d '-' -f1)" >> "$GITHUB_ENV"
-      - name: generate changelog
+          set -euo pipefail
+          git fetch --tags --force
+
+          latest_tag="$(git tag --list 'v*' --sort=-v:refname | grep -E '^v[0-9]+[.][0-9]+[.][0-9]+$' | head -n 1)"
+          if [[ -z "${latest_tag}" ]]; then
+            echo "No stable semver tags found (expected vX.Y.Z)" >&2
+            exit 1
+          fi
+
+          version="${latest_tag#v}"
+          IFS='.' read -r major minor patch <<< "${version}"
+          if ! [[ "${major}" =~ ^[0-9]+$ && "${minor}" =~ ^[0-9]+$ && "${patch}" =~ ^[0-9]+$ ]]; then
+            echo "Latest tag ${latest_tag} is not numeric semver" >&2
+            exit 1
+          fi
+
+          next_tag="v${major}.$((minor + 1)).0"
+          echo "previous_tag=${latest_tag}" >> "$GITHUB_OUTPUT"
+          echo "next_tag=${next_tag}" >> "$GITHUB_OUTPUT"
+
+      - name: Generate changelog
+        id: changelog
+        shell: bash
         run: |
-          set -e
-          response=$(curl -L \
-          -X POST \
-          -H "Accept: application/vnd.github+json" \
-          -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-          -H "X-GitHub-Api-Version: 2022-11-28" \
-          https://api.github.com/repos/Edgenesis/shifu/releases/generate-notes \
-          -d '{"tag_name":"${{inputs.tag_name}}","target_commitish":"${{inputs.target_commitish}}","previous_tag_name":"${{inputs.previous_tag_name}}"}')
-          echo $response
-          go run tools/release/release.go "$response"
+          set -euo pipefail
+
+          repo="${{ github.repository }}"
+          previous_tag="${{ steps.version.outputs.previous_tag }}"
+          next_tag="${{ steps.version.outputs.next_tag }}"
+
+          response="$(curl -sSL -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/${repo}/releases/generate-notes" \
+            -d "$(jq -nc --arg tag "${next_tag}" --arg prev "${previous_tag}" --arg target "main" '{tag_name:$tag,target_commitish:$target,previous_tag_name:$prev}')")"
+
+          if [[ -z "$(echo "${response}" | jq -r '.body // empty')" ]]; then
+            echo "Failed to get release notes body from generate-notes API" >&2
+            echo "${response}" >&2
+            exit 1
+          fi
+
+          go run tools/release/release.go "${response}"
+
+          echo "file=CHANGELOG/CHANGELOG-${next_tag}.md" >> "$GITHUB_OUTPUT"
         env:
           AZURE_OPENAI_APIKEY: ${{ secrets.AZURE_OPENAI_APIKEY }}
           AZURE_OPENAI_HOST: ${{ secrets.AZURE_OPENAI_HOST }}
-          DEPLOYMENT_NAME: ${{secrets.DEPLOYMENT_NAME}}
+          DEPLOYMENT_NAME: ${{ secrets.DEPLOYMENT_NAME }}
+          VERSION: ${{ steps.version.outputs.next_tag }}
+
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@v6
         with:
-          commit-message: add changelog for ${{env.VERSION}}
-          title: add changelog for ${{env.VERSION}}
-          body: add changelog for ${{env.VERSION}}
-          branch: changelog-${{env.VERSION}}
+          commit-message: "chore: add changelog for ${{ steps.version.outputs.next_tag }}"
+          title: "chore: add changelog for ${{ steps.version.outputs.next_tag }}"
+          body: "add changelog for ${{ steps.version.outputs.next_tag }}"
+          branch: changelog-${{ steps.version.outputs.next_tag }}
           base: main
+          add-paths: |
+            CHANGELOG/CHANGELOG-${{ steps.version.outputs.next_tag }}.md

--- a/tools/release/gpt/gpt.go
+++ b/tools/release/gpt/gpt.go
@@ -25,8 +25,7 @@ const (
 	FilePermissions     = 0644
 
 	// Content processing
-	LanguageSeparator = "--------"
-	CodeBlockMarker   = "```"
+	CodeBlockMarker = "```"
 )
 
 // Config holds all configuration for the changelog generator
@@ -139,7 +138,6 @@ func (cg *ChangelogGenerator) buildMessages(releaseNotes string) []openai.ChatCo
 	return []openai.ChatCompletionMessageParamUnion{
 		openai.UserMessage(prompts.GreetingPrompts),
 		openai.UserMessage(prompts.TemplateENPrompts),
-		openai.UserMessage(prompts.TemplateZHPrompts),
 		openai.UserMessage(prompts.GeneratePrompts),
 		openai.UserMessage(releaseNotes),
 	}
@@ -173,15 +171,7 @@ func (cg *ChangelogGenerator) callOpenAI(messages []openai.ChatCompletionMessage
 
 // processAndSaveContent processes the AI response and saves changelog files
 func (cg *ChangelogGenerator) processAndSaveContent(content string) error {
-	// Split content into English and Chinese versions
-	parts := strings.Split(content, LanguageSeparator)
-	if len(parts) < 2 {
-		return fmt.Errorf("invalid content format: expected separator '%s' to split English and Chinese versions", LanguageSeparator)
-	}
-
-	// Process content for both languages
-	enContent := cg.processContent(parts[0])
-	zhContent := cg.processContent(parts[1])
+	enContent := cg.processContent(content)
 
 	// Ensure changelog directory exists
 	if err := cg.ensureChangelogDir(); err != nil {
@@ -194,13 +184,7 @@ func (cg *ChangelogGenerator) processAndSaveContent(content string) error {
 		return fmt.Errorf("failed to save English changelog: %w", err)
 	}
 
-	// Save Chinese changelog
-	zhPath := filepath.Join(cg.config.ChangelogDir, fmt.Sprintf("CHANGELOG-%s-zh.md", cg.config.Version))
-	if err := cg.saveFile(zhPath, zhContent); err != nil {
-		return fmt.Errorf("failed to save Chinese changelog: %w", err)
-	}
-
-	logger.Infof("Saved changelogs: %s, %s", enPath, zhPath)
+	logger.Infof("Saved changelog: %s", enPath)
 	return nil
 }
 

--- a/tools/release/gpt/gpt_test.go
+++ b/tools/release/gpt/gpt_test.go
@@ -180,8 +180,8 @@ func TestBuildMessages(t *testing.T) {
 	releaseNotes := "Test release notes"
 	messages := generator.buildMessages(releaseNotes)
 
-	if len(messages) != 5 {
-		t.Errorf("Expected 5 messages, got %d", len(messages))
+	if len(messages) != 4 {
+		t.Errorf("Expected 4 messages, got %d", len(messages))
 	}
 
 	// The last message should be the release notes

--- a/tools/release/prompts/prompts.go
+++ b/tools/release/prompts/prompts.go
@@ -1,7 +1,7 @@
 package prompts
 
 const (
-	GreetingPrompts = `You are a technical release note generator for Shifu, a Kubernetes-native IoT gateway framework. Your task is to transform raw release notes into well-structured changelogs in both English and Chinese.
+	GreetingPrompts = `You are a technical release note generator for Shifu, a Kubernetes-native IoT gateway framework. Your task is to transform raw release notes into a well-structured changelog in English.
 
 Instructions:
 1. Analyze the provided release notes carefully
@@ -10,7 +10,7 @@ Instructions:
 4. Maintain consistency in formatting and terminology
 5. Only include non-empty sections in the final output
 
-I will provide you with templates for both English and Chinese versions.`
+I will provide you with an English template.`
 
 	TemplateENPrompts = `**ENGLISH TEMPLATE:**
 
@@ -46,44 +46,9 @@ I will provide you with templates for both English and Chinese versions.`
 - Use technical terms appropriately for the developer audience
 - Keep descriptions concise but informative`
 
-	TemplateZHPrompts = `**中文模板：**
-
-# 自 [v0.x.0](https://github.com/Edgenesis/shifu/releases/tag/v0.x.0) 以来的变更
-
-## 新功能 🎉
-- [功能描述应该清晰并突出用户受益点]
-
-## Bug 修复 🐛
-- [Bug 修复描述应该说明问题所在以及如何解决]
-
-## 功能增强 ⚡
-- [增强功能描述应该说明对现有功能的改进]
-
-## 文档更新 📚
-- [文档更新、改进或新增指南]
-
-## 依赖项变更 📦
-- [依赖项更新、新增或移除]
-
-## 新贡献者 🌟
-- [新贡献者致谢及 GitHub 用户名]
-
-## Dependabot 自动更新 🤖
-- [来自 Dependabot 的自动依赖项更新]
-
-**完整变更日志**: https://github.com/Edgenesis/shifu/compare/v0.x.0...v0.y.0
-
-**中文版本指南：**
-- 使用简洁明了的中文表达
-- 每个要点以动作词开头（新增、修复、更新、移除等）
-- 明确说明变更内容及其重要性
-- 适当使用技术术语，面向开发者受众
-- 保持描述简洁但信息丰富
-- 遵循中文技术文档的表达习惯`
-
 	GeneratePrompts = `**GENERATION INSTRUCTIONS:**
 
-Now I will provide you with raw release notes data. Please process this data and generate two complete changelog files based on the templates above.
+Now I will provide you with raw release notes data. Please process this data and generate a complete English changelog based on the template above.
 
 **Processing Requirements:**
 1. Analyze each item in the release notes data
@@ -106,17 +71,13 @@ Now I will provide you with raw release notes data. Please process this data and
 8. For Dependabot Updates section: Keep original "Bump [package] from [version] to [version]" format with PR links
 
 **Output Format:**
-- Generate the English version first
-- Then add exactly '--------' as a separator
-- Then generate the Chinese version
 - Output ONLY the markdown content, no other text
 - Do not include template comments/guidelines in the final output
-- Ensure proper translation of technical terms to Chinese
 
 **Quality Standards:**
 - Each bullet point should be a complete, clear statement
 - Use active voice and specific action verbs
 - Include relevant technical details when helpful
 - Maintain professional tone throughout
-- Ensure Chinese translation is natural and technically accurate`
+- Ensure formatting is consistent and readable`
 )


### PR DESCRIPTION
**What this PR does / why we need it**:
- Updates the release changelog workflow to run manually, compute the next release version from existing tags, and open a PR to `main` with the generated changelog.

**Will this PR make the community happier**?
- Yes — it reduces manual release bookkeeping and standardizes the changelog PR flow.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: NONE

**How is this PR tested**
- [ ] unit test
- [ ] e2e test
- [x] other (please specify): YAML parse check for `.github/workflows/release.yml` and `go test ./tools/release/...`

**Special notes for your reviewer**:
- The workflow selects the latest stable `vX.Y.Z` tag (excluding pre-releases) and bumps to `vX.(Y+1).0`.

**Release note**:
```release-note
Add a manual workflow to generate and PR release changelog updates.
```
