### PR TITLE
chore: add changelog for v0.96.0

### DIFF
--- a/CHANGELOG/CHANGELOG-v0.96.0.md
+++ b/CHANGELOG/CHANGELOG-v0.96.0.md
@@ -1,0 +1,11 @@
+# Changelog since [v0.95.0](https://github.com/Edgenesis/shifu/releases/tag/v0.95.0)
+
+## Dependabot Updates 🤖
+
+- Bump k8s.io/apimachinery from 0.35.4 to 0.36.0 in https://github.com/Edgenesis/shifu/pull/1442
+
+- Bump github.com/minio/minio-go/v7 from 7.0.100 to 7.1.0 in https://github.com/Edgenesis/shifu/pull/1446
+
+- Bump github.com/onsi/ginkgo/v2 from 2.28.1 to 2.28.3 in https://github.com/Edgenesis/shifu/pull/1447
+
+**Full Changelog**: https://github.com/Edgenesis/shifu/compare/v0.95.0...v0.96.0


### PR DESCRIPTION
add changelog for v0.96.0

Manual fallback: the workflow_dispatch run generated the v0.95.0 → v0.96.0 metadata, but the Azure OpenAI formatting step failed with 404, so this PR commits the formatted changelog directly.