### PR TITLE
fix: make release tag workflows idempotent

### DIFF
--- a/.github/workflows/release-official-tag.yml
+++ b/.github/workflows/release-official-tag.yml
@@ -79,6 +79,26 @@ jobs:
           echo "Creating official release tag: ${version}"
           echo "Tag target commit: ${target_sha}"
 
+          if existing_json=$(gh release view "${version}" --json isPrerelease,targetCommitish,url 2>/dev/null); then
+            existing_url=$(jq -r '.url // empty' <<< "${existing_json}")
+            existing_target=$(jq -r '.targetCommitish // empty' <<< "${existing_json}")
+            existing_prerelease=$(jq -r '.isPrerelease' <<< "${existing_json}")
+
+            if [[ "${existing_prerelease}" != "false" ]]; then
+              echo "::error::Existing ${version} release is still marked as a pre-release"
+              exit 1
+            fi
+            if [[ "${existing_target}" != "${target_sha}" ]]; then
+              echo "::error::Existing ${version} release targets ${existing_target}, expected ${target_sha}"
+              exit 1
+            fi
+
+            echo "release_url=${existing_url}" >> "$GITHUB_OUTPUT"
+            echo "::notice::Official release already exists: ${existing_url}"
+            echo "::notice::Release ${version} is now the Latest release"
+            exit 0
+          fi
+
           # Create the release (NOT pre-release, becomes "Latest")
           release_url=$(gh release create "${version}" \
             --title "${version}" \

--- a/.github/workflows/release-rc-tag.yml
+++ b/.github/workflows/release-rc-tag.yml
@@ -70,6 +70,25 @@ jobs:
           # Fetch all tags to ensure we have the baseline
           git fetch --tags --force
 
+          if existing_json=$(gh release view "${rc_tag}" --json isPrerelease,targetCommitish,url 2>/dev/null); then
+            existing_url=$(jq -r '.url // empty' <<< "${existing_json}")
+            existing_target=$(jq -r '.targetCommitish // empty' <<< "${existing_json}")
+            existing_prerelease=$(jq -r '.isPrerelease' <<< "${existing_json}")
+
+            if [[ "${existing_prerelease}" != "true" ]]; then
+              echo "::error::Existing ${rc_tag} release is not marked as a pre-release"
+              exit 1
+            fi
+            if [[ "${existing_target}" != "${target_sha}" ]]; then
+              echo "::error::Existing ${rc_tag} release targets ${existing_target}, expected ${target_sha}"
+              exit 1
+            fi
+
+            echo "release_url=${existing_url}" >> "$GITHUB_OUTPUT"
+            echo "::notice::Pre-release already exists: ${existing_url}"
+            exit 0
+          fi
+
           # Create the release with auto-generated notes
           release_url=$(gh release create "${rc_tag}" \
             --prerelease \


### PR DESCRIPTION
## Summary
- Treat already-created RC/stable releases as success when they target the expected merge SHA
- Keep failing if an existing release has the wrong prerelease flag or target
- Prevent Hermes-operated releases from leaving failing duplicate tag workflow runs

## Test plan
- git diff --check
- local guard presence check for both workflow files