### PR TITLE
fix(deviceshifuhttp): forward upstream status code in GET/POST handler

### DIFF
--- a/pkg/deviceshifu/deviceshifuhttp/deviceshifuhttp.go
+++ b/pkg/deviceshifu/deviceshifuhttp/deviceshifuhttp.go
@@ -215,6 +215,7 @@ func (handler DeviceCommandHandlerHTTP) commandHandleFunc() http.HandlerFunc {
 			instructionFuncName, shouldUsePythonCustomProcessing := deviceshifubase.CustomInstructionsPython[handlerInstruction]
 			if !shouldUsePythonCustomProcessing {
 				utils.CopyHeader(w.Header(), resp.Header)
+				w.WriteHeader(resp.StatusCode)
 				_, err := io.Copy(w, resp.Body)
 				if err != nil {
 					logger.Errorf("cannot copy requestBody from requestBody, error: %s", err.Error())


### PR DESCRIPTION
The GET/POST instruction handler in deviceshifuhttp.go copied the response body from the upstream device server but never called WriteHeader with the actual status code. Go's net/http implicitly writes 200 OK on the first write to the ResponseWriter, so any non-2xx response (e.g. 500 from a failed device probe) was silently translated to 200 OK. This breaks status-code-based health checks and monitoring.

Adds w.WriteHeader(resp.StatusCode) before io.Copy, matching the pattern already used by the HTTPCommandline handler in the same file (line ~371).