### PR TITLE
[codex] remove dead shifu.run demo mirror

### DIFF
--- a/azure-pipelines/azure-pipelines.yml
+++ b/azure-pipelines/azure-pipelines.yml
@@ -844,24 +844,6 @@ stages:
             displayName: "test run_demo result"
           - task: CopyFilesOverSSH@0
             condition: succeeded()
-            inputs:
-              sshEndpoint: "shifurun-ssh"
-              contents: |
-                shifu_demo_aio_linux_amd64.tar
-                shifu_demo_aio_linux_arm64.tar
-              targetFolder: "/home/ubuntu/demo-files"
-              readyTimeout: "20000"
-              failOnEmptySource: true
-          - task: SSH@0
-            condition: succeeded()
-            inputs:
-              sshEndpoint: "shifurun-ssh"
-              runOptions: "inline"
-              inline: "sudo cp -R /home/ubuntu/demo-files/* /var/www/demo-site/demo-content"
-              readyTimeout: "20000"
-
-          - task: CopyFilesOverSSH@0
-            condition: succeeded()
             displayName: push demo file to shifu.dev
             inputs:
               sshEndpoint: "shifu.dev"
@@ -895,23 +877,6 @@ stages:
               bash ./test/scripts/deviceshifu-demo-aio.sh build_demo arm64 darwin
               ls -al
             displayName: "Build macOS ARM64 demo"
-          - task: CopyFilesOverSSH@0
-            condition: succeeded()
-            inputs:
-              sshEndpoint: "shifurun-ssh"
-              contents: |
-                shifu_demo_aio_darwin_arm64.tar
-              targetFolder: "/home/ubuntu/demo-files"
-              readyTimeout: "20000"
-              failOnEmptySource: true
-          - task: SSH@0
-            condition: succeeded()
-            inputs:
-              sshEndpoint: "shifurun-ssh"
-              runOptions: "inline"
-              inline: "sudo cp -R /home/ubuntu/demo-files/* /var/www/demo-site/demo-content"
-              readyTimeout: "20000"
-
           - task: CopyFilesOverSSH@0
             condition: succeeded()
             displayName: push demo file to shifu.dev mac


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes the legacy `shifurun-ssh` publish steps from the release demo artifact jobs. The public installer downloads demo packages from `demo.shifu.dev`, and the later `shifu.dev` publish step is the active destination. Keeping the old `shifurun-ssh` step causes release builds to fail before the artifacts can reach `shifu.dev` when `shifu.run` DNS does not resolve.

**Will this PR make the community happier**?

Yes. Tagged releases can publish the demo tarballs to the working `shifu.dev` host without being blocked by a dead legacy mirror.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: N/A

**How is this PR tested**
- [ ] unit test
- [ ] e2e test
- [x] other (please specify): parsed `azure-pipelines/azure-pipelines.yml` as YAML and confirmed no `shifurun` references remain in that pipeline file.

**Special notes for your reviewer**:

Build 21713 failed in `CopyFilesOverSSH` while resolving the old `shifu.run` host. The subsequent `push demo file to shifu.dev` step was skipped because the previous step failed.

**Release note**:
```release-note
NONE
```