### PR TITLE
ci(release): keep GitHub workflows manual

### DIFF
--- a/.github/workflows/release-biweekly-monday.yml
+++ b/.github/workflows/release-biweekly-monday.yml
@@ -1,8 +1,8 @@
 name: Biweekly Release Monday
 
+# The external release agent owns the schedule. Keep this workflow as a
+# manually dispatched fallback so two release orchestrators cannot race.
 on:
-  schedule:
-    - cron: '0 5 * * 1'
   workflow_dispatch:
     inputs:
       dry_run:

--- a/.github/workflows/release-biweekly-wednesday.yml
+++ b/.github/workflows/release-biweekly-wednesday.yml
@@ -1,8 +1,8 @@
 name: Biweekly Release Wednesday
 
+# The external release agent owns the schedule. Keep this workflow as a
+# manually dispatched fallback so two release orchestrators cannot race.
 on:
-  schedule:
-    - cron: '0 5 * * 3'
   workflow_dispatch:
     inputs:
       dry_run:

--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -1,13 +1,9 @@
 # Release RC Workflow
-# Creates release branch and RC pull request when changelog PR is merged
+# Manual fallback for creating a release branch and RC pull request. The
+# external release agent owns normal release orchestration.
 name: Release RC
 
 on:
-  pull_request:
-    branches:
-      - main
-    types:
-      - closed
   workflow_dispatch:
     inputs:
       version_override:
@@ -21,10 +17,6 @@ permissions:
 
 jobs:
   release_rc:
-    if: |
-      github.event_name == 'workflow_dispatch' ||
-      (github.event.pull_request.merged == true &&
-       startsWith(github.head_ref, 'changelog-'))
     runs-on: ubuntu-latest
     steps:
       - name: Generate GitHub App token


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

Removes the scheduled triggers from the biweekly Wednesday and Monday release workflows and removes the merged-changelog trigger from the RC workflow. The workflows remain available through `workflow_dispatch` as manual recovery fallbacks, while the external release agent remains the single normal release owner.

This prevents two independent orchestrators from racing to create branches, pull requests, tags, or releases.

**Will this PR make the community happier**? 

Yes. Releases have one owner, while maintainers retain an explicit manual fallback.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: N/A

**How is this PR tested**
- [ ] unit test
- [ ] e2e test
- [x] other (please specify): `actionlint` on all three modified workflows; `git diff --check`

**Special notes for your reviewer**:

This targets `main` only and does not alter the frozen `release_v0.104.0` branch.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
