### PR TITLE
ci(azure): wait for PowerShell stub readiness

### DIFF
--- a/azure-pipelines/azure-pipelines.yml
+++ b/azure-pipelines/azure-pipelines.yml
@@ -82,9 +82,54 @@ stages:
               command: "build"
               workingDirectory: "$(System.DefaultWorkingDirectory)/cmd/httpstub/powershellstub"
               arguments: "-a -o $(System.DefaultWorkingDirectory)/output/http2powershell.exe"
-          - script: |
-              START "" $(System.DefaultWorkingDirectory)/output/http2powershell.exe
-              curl.exe -d "ls" "http://localhost:11112/issue_cmd"
+          - powershell: |
+              $ErrorActionPreference = "Stop"
+              $ProgressPreference = "SilentlyContinue"
+
+              $stubPath = Join-Path "$(System.DefaultWorkingDirectory)" "output/http2powershell.exe"
+              $stub = Start-Process -FilePath $stubPath -PassThru
+
+              try {
+                $deadline = (Get-Date).AddSeconds(30)
+                $ready = $false
+
+                while ((Get-Date) -lt $deadline) {
+                  if ($stub.HasExited) {
+                    throw "PowerShell stub exited before becoming ready with code $($stub.ExitCode)"
+                  }
+
+                  try {
+                    $health = Invoke-WebRequest `
+                      -Uri "http://localhost:11112/stub_health" `
+                      -UseBasicParsing `
+                      -TimeoutSec 2
+                    if ($health.StatusCode -eq 200) {
+                      $ready = $true
+                      break
+                    }
+                  } catch {
+                    # The server may still be binding; retry until the deadline.
+                  }
+
+                  Start-Sleep -Milliseconds 250
+                }
+
+                if (-not $ready) {
+                  throw "PowerShell stub did not become ready within 30 seconds"
+                }
+
+                Invoke-WebRequest `
+                  -Uri "http://localhost:11112/issue_cmd" `
+                  -Method Post `
+                  -Body "ls" `
+                  -UseBasicParsing `
+                  -TimeoutSec 10
+              } finally {
+                if (-not $stub.HasExited) {
+                  Stop-Process -Id $stub.Id -Force
+                  $stub.WaitForExit()
+                }
+              }
             displayName: test powershell stub
 
       - job: kind_e2e_test_http


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

Makes the Azure Windows PowerShell-stub test wait for the existing `/stub_health` endpoint before posting a command to port `11112`.

The test now:

- starts the stub as a tracked process,
- polls readiness with a bounded 30-second deadline,
- fails immediately if the process exits,
- executes the command only after a successful health response, and
- always terminates the stub in a `finally` block.

This removes the startup race that intermittently produced `curl: (7)` connection failures.

**Will this PR make the community happier**? 

Yes. Windows CI should stop failing simply because the test reaches the service before it has bound its port.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: N/A

**How is this PR tested**
- [ ] unit test
- [ ] e2e test
- [x] other (please specify): Prettier YAML parse/style check; Azure Windows PR job exercises the readiness path

**Special notes for your reviewer**:

This targets `main` only and does not alter the frozen `release_v0.104.0` branch.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
