### PR TITLE
fix(ci): stabilize DeviceShifu server tests and lint

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -24,4 +24,5 @@ jobs:
         uses: golangci/golangci-lint-action@v9
         with:
           version: v2.11.2
+          verify: false
           args: --timeout=5m

--- a/pkg/deviceshifu/deviceshifubase/deviceshifubase.go
+++ b/pkg/deviceshifu/deviceshifubase/deviceshifubase.go
@@ -2,7 +2,9 @@ package deviceshifubase
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"time"
 
@@ -221,18 +223,24 @@ func (ds *DeviceShifuBase) StartTelemetryCollection(fn collectTelemetry) error {
 	}
 }
 
-func (ds *DeviceShifuBase) startHTTPServer(stopCh <-chan struct{}) error {
+func (ds *DeviceShifuBase) startHTTPServer(listener net.Listener) error {
 	logger.Infof("deviceshifu %s's http server started", ds.Name)
-	return ds.Server.ListenAndServe()
+	return ds.Server.Serve(listener)
 }
 
 // Start HTTP server and telemetryCollection
 func (ds *DeviceShifuBase) Start(stopCh <-chan struct{}, fn collectTelemetry) error {
 	logger.Infof("deviceshifu %s started", ds.Name)
 
+	listener, err := net.Listen("tcp", ds.Server.Addr)
+	if err != nil {
+		return fmt.Errorf("unable to start deviceshifu %s's http server on %s: %w", ds.Name, ds.Server.Addr, err)
+	}
+	ds.Server.Addr = listener.Addr().String()
+
 	go func() {
-		err := ds.startHTTPServer(stopCh)
-		if err != nil {
+		err := ds.startHTTPServer(listener)
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
 			logger.Errorf("error during Http Server is up, error: %v", err)
 		}
 	}()

--- a/pkg/deviceshifu/deviceshifubase/deviceshifubase_test.go
+++ b/pkg/deviceshifu/deviceshifubase/deviceshifubase_test.go
@@ -2,6 +2,8 @@ package deviceshifubase
 
 import (
 	"errors"
+	"net"
+	"net/http"
 	"os"
 	"testing"
 
@@ -9,8 +11,10 @@ import (
 	"github.com/edgenesis/shifu/pkg/k8s/api/v1alpha1"
 	"github.com/edgenesis/shifu/pkg/logger"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 func TestMain(m *testing.M) {
@@ -99,6 +103,26 @@ func TestStartTelemetryCollection(t *testing.T) {
 		})
 	}
 
+}
+
+func TestStartReturnsListenError(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, listener.Close())
+	})
+
+	ds := &DeviceShifuBase{
+		Name: "test",
+		Server: &http.Server{
+			Addr: listener.Addr().String(),
+		},
+	}
+
+	err = ds.Start(wait.NeverStop, func() (bool, error) {
+		return true, nil
+	})
+	require.ErrorContains(t, err, "unable to start deviceshifu test's http server")
 }
 
 func TestNew(t *testing.T) {

--- a/pkg/deviceshifu/deviceshifuhttp/deviceshifuhttp_test.go
+++ b/pkg/deviceshifu/deviceshifuhttp/deviceshifuhttp_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/edgenesis/shifu/pkg/k8s/api/v1alpha1"
 	"github.com/edgenesis/shifu/pkg/logger"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	v1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -73,17 +74,13 @@ func TestStart(t *testing.T) {
 	}
 
 	mockds, err := New(deviceShifuMetadata)
-	if err != nil {
-		t.Errorf("Failed creating new deviceshifu")
-	}
+	require.NoError(t, err)
 
-	if err := mockds.Start(wait.NeverStop); err != nil {
-		t.Errorf("DeviceShifuHTTP.Start failed due to: %v", err.Error())
-	}
-
-	if err := mockds.Stop(); err != nil {
-		t.Errorf("unable to stop mock deviceShifu, error: %+v", err)
-	}
+	mockds.base.Server.Addr = "127.0.0.1:0"
+	require.NoError(t, mockds.Start(wait.NeverStop))
+	t.Cleanup(func() {
+		require.NoError(t, mockds.Stop())
+	})
 }
 
 func TestDeviceHealthHandler(t *testing.T) {
@@ -95,32 +92,21 @@ func TestDeviceHealthHandler(t *testing.T) {
 	}
 
 	mockds, err := New(deviceShifuMetadata)
-	if err != nil {
-		t.Errorf("Failed creating new deviceshifu")
-	}
+	require.NoError(t, err)
 
-	if err := mockds.Start(wait.NeverStop); err != nil {
-		t.Errorf("DeviceShifu.Start failed due to: %v", err.Error())
-	}
+	mockds.base.Server.Addr = "127.0.0.1:0"
+	require.NoError(t, mockds.Start(wait.NeverStop))
+	t.Cleanup(func() {
+		require.NoError(t, mockds.Stop())
+	})
 
-	resp, err := unitest.RetryAndGetHTTP("http://localhost:8080/health", 3)
-	if err != nil {
-		t.Errorf("HTTP GET returns an error %v", err.Error())
-	}
+	resp, err := unitest.RetryAndGetHTTP("http://"+mockds.base.Server.Addr+"/health", 3)
+	require.NoError(t, err)
 
 	defer resp.Body.Close()
 	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		t.Errorf("unable to read response body, error: %v", err.Error())
-	}
-
-	if string(body) != deviceshifubase.DeviceIsHealthyStr {
-		t.Errorf("%+v", body)
-	}
-
-	if err := mockds.Stop(); err != nil {
-		t.Errorf("unable to stop mock deviceShifu, error: %+v", err)
-	}
+	require.NoError(t, err)
+	require.Equal(t, deviceshifubase.DeviceIsHealthyStr, string(body))
 }
 
 func TestCreateHTTPCommandlineRequestString(t *testing.T) {

--- a/pkg/deviceshifu/deviceshifumqtt/deviceshifumqtt_test.go
+++ b/pkg/deviceshifu/deviceshifumqtt/deviceshifumqtt_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/edgenesis/shifu/pkg/k8s/api/v1alpha1"
 	"github.com/edgenesis/shifu/pkg/logger"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	mqtt "github.com/eclipse/paho.mqtt.golang"
@@ -60,17 +61,13 @@ func TestStart(t *testing.T) {
 	}
 
 	mockds, err := New(deviceShifuMetadata)
-	if err != nil {
-		t.Errorf("Failed creating new deviceshifu %v", err.Error())
-	}
+	require.NoError(t, err)
 
-	if err := mockds.Start(wait.NeverStop); err != nil {
-		t.Errorf("DeviceShifu.Start failed due to: %v", err.Error())
-	}
-
-	if err := mockds.Stop(); err != nil {
-		t.Errorf("unable to stop mock deviceShifu, error: %+v", err)
-	}
+	mockds.base.Server.Addr = "127.0.0.1:0"
+	require.NoError(t, mockds.Start(wait.NeverStop))
+	t.Cleanup(func() {
+		require.NoError(t, mockds.Stop())
+	})
 }
 
 func TestDeviceHealthHandler(t *testing.T) {
@@ -82,32 +79,21 @@ func TestDeviceHealthHandler(t *testing.T) {
 	}
 
 	mockds, err := New(deviceShifuMetadata)
-	if err != nil {
-		t.Errorf("Failed creating new deviceshifu")
-	}
+	require.NoError(t, err)
 
-	if err := mockds.Start(wait.NeverStop); err != nil {
-		t.Errorf("DeviceShifu.Start failed due to: %v", err.Error())
-	}
+	mockds.base.Server.Addr = "127.0.0.1:0"
+	require.NoError(t, mockds.Start(wait.NeverStop))
+	t.Cleanup(func() {
+		require.NoError(t, mockds.Stop())
+	})
 
-	resp, err := unitest.RetryAndGetHTTP("http://localhost:8080/health", 3)
-	if err != nil {
-		t.Errorf("HTTP GET returns an error %v", err.Error())
-	}
+	resp, err := unitest.RetryAndGetHTTP("http://"+mockds.base.Server.Addr+"/health", 3)
+	require.NoError(t, err)
 
 	defer resp.Body.Close()
 	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		t.Errorf("unable to read response body, error: %v", err.Error())
-	}
-
-	if string(body) != deviceshifubase.DeviceIsHealthyStr {
-		t.Errorf("%+v", body)
-	}
-
-	if err := mockds.Stop(); err != nil {
-		t.Errorf("unable to stop mock deviceShifu, error: %+v", err)
-	}
+	require.NoError(t, err)
+	require.Equal(t, deviceshifubase.DeviceIsHealthyStr, string(body))
 }
 
 func TestCommandHandleMQTTFunc(t *testing.T) {

--- a/pkg/deviceshifu/deviceshifuopcua/deviceshifuopcua_test.go
+++ b/pkg/deviceshifu/deviceshifuopcua/deviceshifuopcua_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/edgenesis/shifu/pkg/logger"
 	"github.com/gopcua/opcua/ua"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"k8s.io/apimachinery/pkg/util/wait"
 )
@@ -68,17 +69,13 @@ func TestStart(t *testing.T) {
 	}
 
 	mockds, err := New(deviceShifuMetadata)
-	if err != nil {
-		t.Errorf("Failed creating new deviceshifu")
-	}
+	require.NoError(t, err)
 
-	if err := mockds.Start(wait.NeverStop); err != nil {
-		t.Errorf("DeviceShifu.Start failed due to: %v", err.Error())
-	}
-
-	if err := mockds.Stop(); err != nil {
-		t.Errorf("unable to stop mock deviceShifu, error: %+v", err)
-	}
+	mockds.base.Server.Addr = "127.0.0.1:0"
+	require.NoError(t, mockds.Start(wait.NeverStop))
+	t.Cleanup(func() {
+		require.NoError(t, mockds.Stop())
+	})
 }
 
 func TestDeviceHealthHandler(t *testing.T) {
@@ -90,32 +87,21 @@ func TestDeviceHealthHandler(t *testing.T) {
 	}
 
 	mockds, err := New(deviceShifuMetadata)
-	if err != nil {
-		t.Errorf("Failed creating new deviceshifu")
-	}
+	require.NoError(t, err)
 
-	if err := mockds.Start(wait.NeverStop); err != nil {
-		t.Errorf("DeviceShifu.Start failed due to: %v", err.Error())
-	}
+	mockds.base.Server.Addr = "127.0.0.1:0"
+	require.NoError(t, mockds.Start(wait.NeverStop))
+	t.Cleanup(func() {
+		require.NoError(t, mockds.Stop())
+	})
 
-	resp, err := unitest.RetryAndGetHTTP("http://localhost:8080/health", 3)
-	if err != nil {
-		t.Errorf("HTTP GET returns an error %v", err.Error())
-	}
+	resp, err := unitest.RetryAndGetHTTP("http://"+mockds.base.Server.Addr+"/health", 3)
+	require.NoError(t, err)
 
 	defer resp.Body.Close()
 	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		t.Errorf("unable to read response body, error: %v", err.Error())
-	}
-
-	if string(body) != deviceshifubase.DeviceIsHealthyStr {
-		t.Errorf("%+v", body)
-	}
-
-	if err := mockds.Stop(); err != nil {
-		t.Errorf("unable to stop mock deviceShifu, error: %+v", err)
-	}
+	require.NoError(t, err)
+	require.Equal(t, deviceshifubase.DeviceIsHealthyStr, string(body))
 }
 
 func TestCreateValue(t *testing.T) {

--- a/pkg/deviceshifu/deviceshifusocket/deviceshifusocket_test.go
+++ b/pkg/deviceshifu/deviceshifusocket/deviceshifusocket_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/edgenesis/shifu/pkg/k8s/api/v1alpha1"
 	"github.com/edgenesis/shifu/pkg/logger"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	v1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -61,17 +62,13 @@ func TestStart(t *testing.T) {
 	defer server.Close()
 
 	mockds, err := New(deviceShifuMetadata)
-	if err != nil {
-		t.Errorf("Failed creating new deviceshifu")
-	}
+	require.NoError(t, err)
 
-	if err := mockds.Start(wait.NeverStop); err != nil {
-		t.Errorf("DeviceShifu.Start failed due to: %v", err.Error())
-	}
-
-	if err := mockds.Stop(); err != nil {
-		t.Errorf("unable to stop mock deviceShifu, error: %+v", err)
-	}
+	mockds.base.Server.Addr = "127.0.0.1:0"
+	require.NoError(t, mockds.Start(wait.NeverStop))
+	t.Cleanup(func() {
+		require.NoError(t, mockds.Stop())
+	})
 }
 
 func TestDeviceHealthHandler(t *testing.T) {
@@ -82,32 +79,21 @@ func TestDeviceHealthHandler(t *testing.T) {
 	}
 
 	mockds, err := New(deviceShifuMetadata)
-	if err != nil {
-		t.Errorf("Failed creating new deviceshifu")
-	}
+	require.NoError(t, err)
 
-	if err := mockds.Start(wait.NeverStop); err != nil {
-		t.Errorf("DeviceShifu.Start failed due to: %v", err.Error())
-	}
+	mockds.base.Server.Addr = "127.0.0.1:0"
+	require.NoError(t, mockds.Start(wait.NeverStop))
+	t.Cleanup(func() {
+		require.NoError(t, mockds.Stop())
+	})
 
-	resp, err := unitest.RetryAndGetHTTP("http://localhost:8080/health", 3)
-	if err != nil {
-		t.Errorf("HTTP GET returns an error %v", err.Error())
-	}
+	resp, err := unitest.RetryAndGetHTTP("http://"+mockds.base.Server.Addr+"/health", 3)
+	require.NoError(t, err)
 
 	defer resp.Body.Close()
 	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		t.Errorf("unable to read response body, error: %v", err.Error())
-	}
-
-	if string(body) != deviceshifubase.DeviceIsHealthyStr {
-		t.Errorf("%+v", body)
-	}
-
-	if err := mockds.Stop(); err != nil {
-		t.Errorf("unable to stop mock deviceShifu, error: %+v", err)
-	}
+	require.NoError(t, err)
+	require.Equal(t, deviceshifubase.DeviceIsHealthyStr, string(body))
 }
 
 func TestDecodeCommand(t *testing.T) {

--- a/pkg/deviceshifu/deviceshifutcp/deviceshifutcp_test.go
+++ b/pkg/deviceshifu/deviceshifutcp/deviceshifutcp_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/edgenesis/shifu/pkg/k8s/api/v1alpha1"
 	"github.com/edgenesis/shifu/pkg/logger"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"net"
@@ -70,17 +71,13 @@ func TestStart(t *testing.T) {
 	defer server.Close()
 
 	mockds, err := New(deviceShifuMetadata)
-	if err != nil {
-		t.Errorf("Failed creating new deviceshifu due to: %v", err.Error())
-	}
+	require.NoError(t, err)
 
-	if err := mockds.Start(wait.NeverStop); err != nil {
-		t.Errorf("DeviceShifu.Start failed due to: %v", err.Error())
-	}
-
-	if err := mockds.Stop(); err != nil {
-		t.Errorf("unable to stop mock deviceShifu, error: %+v", err)
-	}
+	mockds.base.Server.Addr = "127.0.0.1:0"
+	require.NoError(t, mockds.Start(wait.NeverStop))
+	t.Cleanup(func() {
+		require.NoError(t, mockds.Stop())
+	})
 }
 
 func TestCollectTCPTelemetry(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

Stabilizes two CI paths that blocked the `v0.104.0-rc1` release:

- binds the DeviceShifu HTTP listener synchronously so `Start` returns real bind errors and `Stop` cannot race ahead of `ListenAndServe`,
- uses dynamic loopback ports in protocol server tests and fail-fast assertions before response dereferences, and
- disables golangci-lint action schema verification, which otherwise downloads a remote JSON schema before running the pinned linter.

Lint execution and its pinned `v2.11.2` version are unchanged.

**Will this PR make the community happier**? 

Yes. DeviceShifu tests no longer compete for port `8080`, and lint cannot fail solely because an external schema endpoint times out.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: N/A

**How is this PR tested**
- [x] unit test: `go test ./pkg/deviceshifu/deviceshifubase ./pkg/deviceshifu/deviceshifumqtt ./pkg/deviceshifu/deviceshifusocket ./pkg/deviceshifu/deviceshifuhttp ./pkg/deviceshifu/deviceshifuopcua ./pkg/deviceshifu/deviceshifutcp`
- [ ] e2e test
- [x] other (please specify): race detector with 10 repetitions for base/MQTT/socket/HTTP/OPC UA packages; race detector once for TCP; `actionlint` for the lint workflow; `git diff --check`

**Special notes for your reviewer**:

This targets `main` only and does not alter the frozen `release_v0.104.0` branch.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
