### PR TITLE
chore: add changelog for v0.105.0

### DIFF
--- a/CHANGELOG/CHANGELOG-v0.105.0.md
+++ b/CHANGELOG/CHANGELOG-v0.105.0.md
@@ -1,0 +1,13 @@
+# Changelog since [v0.104.0](https://github.com/Edgenesis/shifu/releases/tag/v0.104.0)
+
+## Dependabot Updates 🤖
+
+- Bump github.com/microsoft/go-mssqldb from 1.10.0 to 1.11.0 in https://github.com/Edgenesis/shifu/pull/1530
+
+- Bump k8s.io/client-go from 0.36.4 to 0.37.0 in https://github.com/Edgenesis/shifu/pull/1533
+
+- Bump github.com/pion/dtls/v3 from 3.1.5 to 3.1.6 in https://github.com/Edgenesis/shifu/pull/1534
+
+- Bump github.com/onsi/gomega from 1.42.1 to 1.43.0 in https://github.com/Edgenesis/shifu/pull/1536
+
+**Full Changelog**: https://github.com/Edgenesis/shifu/compare/v0.104.0...v0.105.0


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds the v0.105.0 changelog for the Sep 9 release candidate, using v0.104.0 as the previous stable baseline. Records the dependency updates included in this release.

**Will this PR make the community happier**?

Yes. Provides a reviewable release summary and dependency-upgrade links before RC publication.

**Which issue this PR fixes**:

N/A — routine release preparation.

**How is this PR tested**
- [ ] unit test
- [ ] e2e test
- [x] other: documentation-only change; release notes and comparison baseline reviewed. Required CI must pass before merge.

**Special notes for your reviewer**:

Part of the authorized recovery of the Sep 9 v0.105.0-rc1 release. No runtime source changes in this PR. Stable promotion remains on its separate scheduled release date.

**Release note**:
```release-note
NONE
```
